### PR TITLE
Error handling for regions' secretsmanager api does not provide TAGS #73

### DIFF
--- a/services/rds/Rds.py
+++ b/services/rds/Rds.py
@@ -98,6 +98,10 @@ class Rds(Service):
     def registerSecrets(self, results):
         for secret in results.get('SecretList'):
             if self.tags:
+                if not 'Tags' in secret:
+                    print('Tags not supported in this region: [{}], ignoring tags filter'.format(self.region))
+                    continue
+                
                 if self.resourceHasTags(secret['Tags']) == False:
                     continue
             


### PR DESCRIPTION
# Description

Error handling for issue #73 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Single Account, Single Service and Single Region
- [x] Single Account, Single Service and Multiple Regions

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this change with all regions and services
