### PR TITLE
Typo on CloudTrail reporter

### DIFF
--- a/services/cloudwatch/cloudwatch.reporter.json
+++ b/services/cloudwatch/cloudwatch.reporter.json
@@ -155,7 +155,7 @@
 			"[CIS Cloudwatch Guide 12]<https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-12>"
 		]
 	},
-	"trailWOMASecGroup13": {
+	"trailWOMARouteTable13": {
 		"category": "O",
 		"^description": "CIS recommends that you create a metric filter and alarm for changes to route tables. Monitoring these changes helps ensure that all VPC traffic flows through an expected path.",
 		"shortDesc": "Create alarm: Route Table changes",


### PR DESCRIPTION
Missing 'trailWOMARouteTable13' in reporter. Was a typo.