### PR TITLE
make both api-full and report mode output the api.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,6 @@ screener --regions ALL
 
 ### Other parameters
 ```bash
-##mode
---mode api-full | api-raw | report
-
-# api-full: give full results in JSON format
-# api-raw: raw findings
-# report: generate default web html
-
-##others
 # AWS Partner used, migration evaluation id
 --others '{"mpe": {"id": "aaaa-1111-cccc"}}'
 
@@ -153,6 +145,11 @@ You can navigate to the service(s) listed to see detailed findings on each servi
 The report provides you an easy-to-navigate dashboard of the various best-practice checks that were run. 
 
 Use the left navigation bar to explore the checks for each service. Expand each check to read the description, find out which resources were highlighted, and get recommendations on how to remediate the findings.  
+
+Besides the HTML report, you can also find two JSON files that record the findings in each AWS account's folder:
+
+- `api-raw.json`: Contains the raw findings
+- `api-full.json`: Contains the full results in JSON format
 
 ## Contributing to service-screener
 We encourage public contributions! Please review [CONTRIBUTING](./CONTRIBUTING.md) for details on our code of conduct and development process.

--- a/Screener.py
+++ b/Screener.py
@@ -179,96 +179,93 @@ class Screener:
     
     
     @staticmethod    
-    def generateScreenerOutput(runmode, contexts, hasGlobal, regions, uploadToS3):
+    def generateScreenerOutput(contexts, hasGlobal, regions, uploadToS3):
         htmlFolder = Config.get('HTML_ACCOUNT_FOLDER_FULLPATH')
         if not os.path.exists(htmlFolder):
             os.makedirs(htmlFolder)
         
         stsInfo = Config.get('stsInfo')
-        if runmode == 'api-raw':
-            with open(htmlFolder + '/api.json', 'w') as f:
-                json.dump(contexts, f)
-        else:
-            cp = CustomPage()
-            pages = cp.getRegistrar()
-            Config.set('CustomPage::Pages', pages)
-            
-            apiResultArray = {}
-            if hasGlobal:
-                regions.append('GLOBAL')
-            
-            if runmode == 'report':
-                params = []
-                for key, val in Config.get('_SS_PARAMS').items():
-                    if val != '':
-                        tmp = '--' + key + ' ' + str(val)
-                        params.append(tmp)
-                        
-                summary = Config.get('SCREENER-SUMMARY')
-                excelObj = ExcelBuilder(stsInfo['Account'], ' '.join(params))
-            
-            for service, dataSets in contexts.items():
-                resultSets = dataSets['results']
-                chartSets = dataSets['charts']
 
-                reporter = Reporter(service)
-                reporter.process(resultSets).processCharts(chartSets).getSummary().getDetails()
-                
-                if runmode == 'report':
-                    ## <TODO> -- verification
-                    ## Maybe need to import module, to validate later
-                    pageBuilderClass = Screener.getServicePagebuilderDynamically(service)
-                    pb = pageBuilderClass(service, reporter)
-                    pb.buildPage()
-                    
-                    ## <TODO>
-                    if service not in ['guardduty']:
-                        excelObj.generateWorkSheet(service, reporter.cardSummary)
-                
-                if runmode == 'report' or runmode == 'api-full':
-                    if not service in apiResultArray:
-                        apiResultArray[service] = {'summary': {}, 'detail': {}}
-                    
-                    apiResultArray[service]['summary'] = reporter.getCard()
-                    apiResultArray[service]['detail'] = reporter.getDetail()
-            
-            if runmode == 'report':
-                # serviceStat = Config.get('cli_services')
-                # print(serviceStat)
-                dashPB = DashboardPageBuilder('index', [])
-                dashPB.buildPage()
-                
-                # <TODO>
-                ## dashPB will gather summary info, hence rearrange the sequences
-                excelObj.buildSummaryPage(summary)
-                excelObj._save()
-                
-                ## Enhancement - Framework
-                frameworks = Config.get('cli_frameworks')
-                if len(frameworks) > 0:
-                    for framework in frameworks:
-                        o = FrameworkPageBuilder(framework, apiResultArray)
-                        if o.getGateCheckStatus() == True:
-                            p = o.buildPage()
-                        else:
-                            print(framework + " GATECHECK==FALSE")
-                
-                emsg = []
-                try:
-                    cp.buildPage()
-                except Exception:
-                    print(traceback.format_exc())
-                    emsg.append(traceback.format_exc())
-                
-                if emsg:
-                    with open(_C.FORK_DIR + '/error.txt', 'a+') as f:
-                        f.write('\n\n'.join(emsg))
-                        f.close()
-                
-                reporter.resetDashboard()
-                cp.resetPages()
-                del cp
+        # generate raw findings json file
+        with open(htmlFolder + '/api-raw.json', 'w') as f:
+            json.dump(contexts, f)
 
-            # make both api-full and report mode output the api.json file
-            with open(htmlFolder + "/api.json", "w") as f:
-                json.dump(apiResultArray, f)
+        cp = CustomPage()
+        pages = cp.getRegistrar()
+        Config.set("CustomPage::Pages", pages)
+
+        apiResultArray = {}
+        if hasGlobal:
+            regions.append('GLOBAL')
+
+        params = []
+        for key, val in Config.get('_SS_PARAMS').items():
+            if val != '':
+                tmp = '--' + key + ' ' + str(val)
+                params.append(tmp)
+
+        summary = Config.get("SCREENER-SUMMARY")
+        excelObj = ExcelBuilder(stsInfo["Account"], " ".join(params))
+
+        for service, dataSets in contexts.items():
+            resultSets = dataSets['results']
+            chartSets = dataSets['charts']
+
+            reporter = Reporter(service)
+            reporter.process(resultSets).processCharts(chartSets).getSummary().getDetails()
+
+            ## <TODO> -- verification
+            ## Maybe need to import module, to validate later
+            pageBuilderClass = Screener.getServicePagebuilderDynamically(service)
+            pb = pageBuilderClass(service, reporter)
+            pb.buildPage()
+
+            ## <TODO>
+            if service not in ['guardduty']:
+                excelObj.generateWorkSheet(service, reporter.cardSummary)
+
+            if not service in apiResultArray:
+                apiResultArray[service] = {'summary': {}, 'detail': {}}
+            
+            apiResultArray[service]['summary'] = reporter.getCard()
+            apiResultArray[service]['detail'] = reporter.getDetail()
+
+        # serviceStat = Config.get('cli_services')
+        # print(serviceStat)
+        dashPB = DashboardPageBuilder('index', [])
+        dashPB.buildPage()
+
+        # <TODO>
+        ## dashPB will gather summary info, hence rearrange the sequences
+        excelObj.buildSummaryPage(summary)
+        excelObj._save()
+
+        ## Enhancement - Framework
+        frameworks = Config.get('cli_frameworks')
+        if len(frameworks) > 0:
+            for framework in frameworks:
+                o = FrameworkPageBuilder(framework, apiResultArray)
+                if o.getGateCheckStatus() == True:
+                    p = o.buildPage()
+                else:
+                    print(framework + " GATECHECK==FALSE")
+
+        emsg = []
+        try:
+            cp.buildPage()
+        except Exception:
+            print(traceback.format_exc())
+            emsg.append(traceback.format_exc())
+
+        if emsg:
+            with open(_C.FORK_DIR + '/error.txt', 'a+') as f:
+                f.write('\n\n'.join(emsg))
+                f.close()
+
+        reporter.resetDashboard()
+        cp.resetPages()
+        del cp
+
+        # generate the full results in JSON format
+        with open(htmlFolder + "/api-full.json", "w") as f:
+            json.dump(apiResultArray, f)

--- a/Screener.py
+++ b/Screener.py
@@ -268,6 +268,7 @@ class Screener:
                 reporter.resetDashboard()
                 cp.resetPages()
                 del cp
-            else:
-                with open(htmlFolder + '/api.json', 'w') as f:
-                    json.dump(apiResultArray, f)
+
+            # make both api-full and report mode output the api.json file
+            with open(htmlFolder + "/api.json", "w") as f:
+                json.dump(apiResultArray, f)

--- a/main.py
+++ b/main.py
@@ -31,7 +31,6 @@ debugFlag = _cli_options['debug']
 # feedbackFlag = _cli_options['feedback']
 # testmode = _cli_options['dev']
 testmode = _cli_options['ztestmode']
-runmode = _cli_options['mode']
 filters = _cli_options['tags']
 crossAccounts = _cli_options['crossAccounts']
 workerCounts = _cli_options['workerCounts']
@@ -44,7 +43,6 @@ crossAccounts = True if crossAccounts in _C.CLI_TRUE_KEYWORD_ARRAY or crossAccou
 beta = True if beta in _C.CLI_TRUE_KEYWORD_ARRAY or beta is True else False
 _cli_options['crossAccounts'] = crossAccounts
 
-runmode = runmode if runmode in ['api-raw', 'api-full', 'report'] else 'report'
 
 # <TODO> analyse the impact profile switching
 _AWS_OPTIONS = {
@@ -318,7 +316,7 @@ for acctId, cred in rolesCred.items():
     Config.set('cli_regions', regions)
     Config.set('cli_frameworks', frameworks)
     
-    Screener.generateScreenerOutput(runmode, contexts, hasGlobal, regions, uploadToS3)
+    Screener.generateScreenerOutput(contexts, hasGlobal, regions, uploadToS3)
     
     # os.chdir(_C.FORK_DIR)
     filetodel = _C.FORK_DIR + '/tail.txt'
@@ -338,17 +336,7 @@ for acctId, cred in rolesCred.items():
     
 
 adminlteDir = _C.ADMINLTE_ROOT_DIR
-
-if runmode == 'report':
-    shutil.make_archive('output', 'zip', adminlteDir)
-else:
-    apiFolder = _C.ROOT_DIR + '/aws-api'
-    if os.path.exists(apiFolder):
-        shutil.rmtree(apiFolder)
-        
-    shutil.copytree(adminlteDir, apiFolder, ignore=shutil.ignore_patterns('res*'))
-    shutil.make_archive('output', 'zip', apiFolder)
-    shutil.rmtree(apiFolder)
+shutil.make_archive('output', 'zip', adminlteDir)
 
 print("Pages generated, download \033[1;42moutput.zip\033[0m to view")
 print("CloudShell user, you may use this path: \033[1;42m =====> \033[0m /tmp/service-screener-v2/output.zip \033[1;42m <===== \033[0m")

--- a/utils/ArguParser.py
+++ b/utils/ArguParser.py
@@ -9,7 +9,6 @@ class ArguParser:
         "t": "test",
         "p": "profile",
         "b": "bucket",
-        "m": "mode",
         "f": "filters"
     }
     
@@ -48,11 +47,6 @@ class ArguParser:
         "ztestmode": {
             "required": False,
             "default": False
-        },
-        "mode": {
-            "required": False,
-            "default": "report",
-            "help": "--mode report|api|api_full"
         },
         "profile": {
             "required": False,


### PR DESCRIPTION
# Description

Hello! We would love to have the full `api.json` file available also for the `report` mode, and this PR enables it. In our use cases, we sometimes check the generated HTML reports, and also we have automation to analyze the `api.json` file generated by the `api-full` mode. It would be nice to have it available for `report` mode.

If you need to make it as a separate option to not to change the current behavior, please let me know.

Thanks!

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [x] Minor changes

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Single Account, Single Service and Single Region
- [x] Single Account, Single Service and Multiple Regions
- [x] Single Account, Multiple Services and Single Region
- [x] Single Account, Multiple Services and Multiple Regions
- [x] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
