### PR TITLE
fix obj variable referenced before assignment error

### DIFF
--- a/services/elasticache/Elasticache.py
+++ b/services/elasticache/Elasticache.py
@@ -189,6 +189,7 @@ class Elasticache(Service):
             return objs
 
         for cluster in self.cluster_info:
+            obj = None
             if cluster.get('Engine') == 'memcached':
                 obj = ElasticacheMemcached(
                     cluster, self.elasticacheClient, self.driverInfo)


### PR DESCRIPTION
# Description

Now ElastiCache also supports `Valkey` engine, which may trigger a variable referenced before assignment error and break the scanner. Here are some error logs regarding this.

```
Traceback (most recent call last):
  File ".../.pyenv/versions/3.10.6/lib/python3.10/site-packages/multiprocess/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File ".../.pyenv/versions/3.10.6/lib/python3.10/site-packages/multiprocess/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File ".../service-screener-v2/Screener.py", line 87, in scanByService
    resp = serv.advise()
  File ".../service-screener-v2/services/elasticache/Elasticache.py", line 199, in advise
    if obj is not None:
UnboundLocalError: local variable 'obj' referenced before assignment
```

This PR fixes the issue by declaring the variable `obj` first. Later on, there should be a driver class for `ElasticacheValkey` but I haven't got time to work on it now.

Fixes # (issue)

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Single Account, Single Service and Single Region
- [ ] Single Account, Single Service and Multiple Regions
- [ ] Single Account, Multiple Services and Single Region
- [ ] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
