### PR TITLE
feat: Add nowrite option to make the tool work with readonly permissions

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -23,7 +23,7 @@ API_JSON = FORK_DIR + '/api.json'
 
 GENERAL_CONF_PATH = SERVICE_DIR + '/general.reporter.json'
 
-CLI_TRUE_KEYWORD_ARRAY = ['yes', 'y', 'true', '1', 1]
+CLI_TRUE_KEYWORD_ARRAY = ['yes', 'y', 'true', 'True', '1', 1]
 
 SESSUID_FILENAME = 'sess-uuid'
 

--- a/main.py
+++ b/main.py
@@ -35,12 +35,15 @@ filters = _cli_options['tags']
 crossAccounts = _cli_options['crossAccounts']
 workerCounts = _cli_options['workerCounts']
 beta = _cli_options['beta']
+nowrite = _cli_options['nowrite']
+
 
 # print(crossAccounts)
 DEBUG = True if debugFlag in _C.CLI_TRUE_KEYWORD_ARRAY or debugFlag is True else False
 testmode = True if testmode in _C.CLI_TRUE_KEYWORD_ARRAY or testmode is True else False
 crossAccounts = True if crossAccounts in _C.CLI_TRUE_KEYWORD_ARRAY or crossAccounts is True else False
 beta = True if beta in _C.CLI_TRUE_KEYWORD_ARRAY or beta is True else False
+nowrite = True if nowrite in _C.CLI_TRUE_KEYWORD_ARRAY or nowrite is True else False
 _cli_options['crossAccounts'] = crossAccounts
 
 
@@ -97,7 +100,9 @@ for file in os.listdir(_C.ADMINLTE_DIR):
         shutil.rmtree(_C.ADMINLTE_DIR + '/' + file)
 
 acctLoop = 0
-CfnTrailObj = CfnTrail()
+
+if nowrite == False:
+    CfnTrailObj = CfnTrail()
 
 for acctId, cred in rolesCred.items():
     acctLoop = acctLoop + 1
@@ -193,7 +198,7 @@ for acctId, cred in rolesCred.items():
             print(f"Error decoding JSON: {e}")
             exit()
 
-    if testmode == False:
+    if testmode == False and nowrite == False:
         cfnAdditionalStr = None
         if mpeid is not None: 
             cfnAdditionalStr = " --mpeid:{}".format(mpeid)
@@ -233,7 +238,7 @@ for acctId, cred in rolesCred.items():
     pool.starmap(Screener.scanByService, input_ranges)
     pool.close()
 
-    if testmode == False:
+    if testmode == False and nowrite == False:
         CfnTrailObj.deleteStack()
     
     ## <TODO>

--- a/utils/ArguParser.py
+++ b/utils/ArguParser.py
@@ -79,7 +79,13 @@ class ArguParser:
             "required": False,
             "default": False,
             "help": "Enable Beta features"
+        },
+        'nowrite': {
+            "required": False,
+            "default": False,
+            "help": "Enable Read-Only mode, no cloudformation required"
         }
+        
     }
 
     @staticmethod


### PR DESCRIPTION
# Description

Add option nowrite to disable the cloudformation creation. This allows the tool to run with readonly permissions

Fixes #178

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Single Account, Single Service and Single Region
- [x] Single Account, Single Service and Multiple Regions
- [x] Single Account, Multiple Services and Single Region
- [x] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with all regions and services
- [x] Any dependent changes have been merged and published in downstream modules
