### PR TITLE
Use "standard" boto3 retries instead of default legacy mode

### DIFF
--- a/services/Service.py
+++ b/services/Service.py
@@ -26,7 +26,11 @@ class Service:
         self.RULESPREFIX = classname + '::rules'
         self.region = region
         self.bConfig = bConfig(
-            region_name = region    
+            region_name = region,
+            retries = {
+                'mode': 'standard',
+                'max_attempts': 5
+            }
         )
         
         self.charts = {}


### PR DESCRIPTION
# Description

Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html

"botocore.exceptions.CredentialRetrievalError: Error when retrieving credentials from container-role: Error retrieving metadata: Received non 200 response 429 from container metadata"

Fixes #189 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Single Account, Single Service and Single Region
- [x] Single Account, Single Service and Multiple Regions
- [x] Single Account, Multiple Services and Single Region
- [x] Single Account, Multiple Services and Multiple Regions