### PR TITLE
Fix GlobalEndpointTokenVersion check

### DIFF
--- a/utils/CrossAccountsValidator.py
+++ b/utils/CrossAccountsValidator.py
@@ -117,61 +117,65 @@ class CrossAccountsValidator():
             self.iamClient.set_security_token_service_preferences(
                 GlobalEndpointTokenVersion='v1Token'    
             )
-        
+
     def validateRoles(self):
         canProceedFlag = True
-        
         generalDicts = self.crossAccountsDict['general']
-        
+    
         for acct, cfg in self.crossAccountsDict['accountLists'].items():
             params = {**generalDicts, **cfg}
             res = {k: v for k, v in params.items() if v}
-            
+        
             res['RoleSessionName'] = self.DEFAULT_ROLESESSIONNAME    
             res['RoleArn'] = self.getRoleArn(acct, None if not 'RoleName' in res else res['RoleName'])
             res['DurationSeconds'] = self.DEFAULT_DURATIONSECONDS
             res.pop('RoleName')
-            
-            
+        
             sts = boto3.client('sts')
-            
-            tokenCheckPass = False
-            tokenCheckCounter = 1
+        
             try:
-                while(tokenCheckPass == False and tokenCheckCounter <= self.MAXTOKENCHECKRETRY):
+                if self.REQUIRES_V2TOKEN:
+                    # Only check token length if V2 token is required
+                    tokenCheckPass = False
+                    tokenCheckCounter = 1
+                    while(tokenCheckPass == False and tokenCheckCounter <= self.MAXTOKENCHECKRETRY):
+                        resp = sts.assume_role(**res)
+                        cred = resp.get('Credentials')
+                        if len(cred['SessionToken']) < 700:
+                            print('Attempt #{}. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in {} seconds'
+                                  .format(tokenCheckCounter, self.WAIT_TOKENCHECKRETRY))
+                            tokenCheckCounter = tokenCheckCounter + 1
+                            time.sleep(self.WAIT_TOKENCHECKRETRY)
+                        else:
+                            tokenCheckPass = True
+                
+                    if tokenCheckPass == False:
+                        print('... unable to acquired V2 token ...')
+                        canProceedFlag = False
+                        break
+                else:
+                    # For default regions, just assume the role once
                     resp = sts.assume_role(**res)
                     cred = resp.get('Credentials')
-                    if len(cred['SessionToken']) < 700:
-                        print('Attempt #{}. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in {} seconds'.format(tokenCheckCounter, self.WAIT_TOKENCHECKRETRY))
-                        tokenCheckCounter = tokenCheckCounter + 1
-                        time.sleep(self.WAIT_TOKENCHECKRETRY)
-                    else:
-                        tokenCheckPass = True
-                        
-                if tokenCheckPass == False:
-                    print('... unable to acquired V2 token ...')
-                    canProceedFlag = False
-                    break
-                
+            
                 if 'AccessKeyId' in cred and 'SecretAccessKey' in cred and 'SessionToken' in cred:
                     print('[\u2714] {}, assume_role passed'.format(acct))
-                    
+                
                     self.ROLEINFO[acct] = {
                         'aws_access_key_id': cred['AccessKeyId'],
                         'aws_secret_access_key': cred['SecretAccessKey'],
                         'aws_session_token': cred['SessionToken']
                     }
-                    
+                
             except botocore.exceptions.ClientError as err:
                 canProceedFlag = False
                 _warn("Unable to assume role, read more below")
                 print('AcctId: {}'.format(acct), str(err))
                 print(res)
-                
                 break
-          
+      
         return canProceedFlag
-    
+ 
     def getRoleArn(self, acctId, roleName):
         if roleName == None:
             roleName = self.DEFAULT_ROLENAME


### PR DESCRIPTION
# Description

When running cross account , app tries to switch to GlobalEndpointTokenVersion 2 in default region, fails and exits.

Fixes # (issue)

Run V2 if the check is actually warranted.

## Type of change

- [ *] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When running with: adjusted crossAccounts.json

{
    "general": {
        "IncludeThisAccount": true
    },
    "accountLists": {
         "123456789101": {
            "ExternalId": "sample-sandbox",
            "RoleName": "My-ReadOnly-ScreenerRole"
        }
    }
}

(screener) service-screener-v2 $ screener -r eu-central-1 -c 1
Default region(s) detected, no need to change IAM:GlobalEndpointToken
Attempt #1. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
Attempt #2. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
Attempt #3. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
Attempt #4. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
Attempt #5. Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
... unable to acquired V2 token ...
Cross Account Roles failed
CrossAccountsFlag=True but failed to validate, exit...

After applying the code change, the application goes to the actual testing. Also, when specifying ALL as region, application does not hang and still runs successful. 

(screener) service-screener-v2 $ screener -r ALL -c 1
Detected GlobalEndpointTokenVersion=1, changing to 2...
Attempt #1, Waiting IAM GlobalEndpointTokenVersion to reflect V2 token, retry in 3 seconds
[✔] 816069141012, assume_role passed
Cross Accounts Validation completed. Resetting GlobalEndpointTokenVersion=1

- [ *] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [ *] My code follows the style guidelines of this project
- [ * ] I have performed a self-review of my own code
- [ * ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ * ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
