### PR TITLE
Add logic to handle missing attribute for org trail

### DIFF
--- a/services/cloudtrail/drivers/CloudtrailCommon.py
+++ b/services/cloudtrail/drivers/CloudtrailCommon.py
@@ -86,8 +86,9 @@ class CloudtrailCommon(Evaluator):
         
         if not 'IsLogging' in r or r.get('IsLogging') == False:
             self.results['EnableCloudTrailLogging'] = [-1, '']
-            
-        if not r.get('LatestDeliveryError') == 'None':
+        
+        # Only check for delivery errors if the attribute exists and is not 'None'
+        if 'LatestDeliveryError' in r and r.get('LatestDeliveryError') != 'None':
             self.results['TrailDeliverError'] = [-1, r.get('LatestDeliveryError')]
             
     def _checkS3BucketSettings(self):


### PR DESCRIPTION
# Description

This PR addresses a bug where the screener would incorrectly report a high-severity TrailDeliverError finding for organization-wide CloudTrails in member accounts. The root cause was that the code assumed the LatestDeliveryError attribute would always be present in the response from the get_trail_status API call, which is not the case for organization trails.

## Changes

Updated the _checkTrailStatus method in CloudtrailCommon.py to only check for and report TrailDeliverError if the LatestDeliveryError attribute exists in the API response and is not 'None'.
This prevents false positives and ensures that only actual delivery errors are reported.

## Impact

Member accounts in AWS Organizations with only organization-wide CloudTrails will no longer see incorrect high-severity findings for missing delivery errors. The check remains effective for regular trails and will still report real delivery issues.

Fixes #201 

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Single Account, Single Service and Single Region
- [ ] Single Account, Single Service and Multiple Regions
- [ ] Single Account, Multiple Services and Single Region
- [ ] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
