### PR TITLE
Add SOC2 framework for AWS compliance assessment

### DIFF
--- a/frameworks/SOC2/SOC2.py
+++ b/frameworks/SOC2/SOC2.py
@@ -1,0 +1,9 @@
+import json
+
+import constants as _C
+from frameworks.Framework import Framework
+
+class SOC2(Framework):
+    def __init__(self, data):
+        super().__init__(data)
+        pass

--- a/frameworks/SOC2/SOC2PageBuilder.py
+++ b/frameworks/SOC2/SOC2PageBuilder.py
@@ -4,3 +4,23 @@ class SOC2PageBuilder(FrameworkPageBuilder):
     def init(self):
         super().__init__()
         self.template = 'default'
+        
+    def _hookPostBuildContent(self):
+        # Add documentation references to the HTML output
+        self.content += """
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">SOC2 Documentation Resources</h3>
+            </div>
+            <div class="card-body">
+                <p>The following documentation resources are available to help with SOC2 compliance:</p>
+                <ul>
+                    <li><strong>Implementation Guide</strong>: Step-by-step guide for implementing SOC2 compliance in AWS</li>
+                    <li><strong>Remediation Guide</strong>: Detailed remediation steps for common findings</li>
+                    <li><strong>AWS Mapping Guide</strong>: Comprehensive mapping between SOC2 criteria and AWS services</li>
+                </ul>
+                <p>These files are located in the frameworks/SOC2 directory of the service-screener-v2 repository.</p>
+            </div>
+        </div>
+        """
+        return super()._hookPostBuildContent()

--- a/frameworks/SOC2/SOC2PageBuilder.py
+++ b/frameworks/SOC2/SOC2PageBuilder.py
@@ -1,0 +1,6 @@
+from frameworks.FrameworkPageBuilder import FrameworkPageBuilder
+
+class SOC2PageBuilder(FrameworkPageBuilder):
+    def init(self):
+        super().__init__()
+        self.template = 'default'

--- a/frameworks/SOC2/SOC2_AWS_Mapping.md
+++ b/frameworks/SOC2/SOC2_AWS_Mapping.md
@@ -1,0 +1,154 @@
+# SOC2 Framework for AWS - Detailed Mapping Guide
+
+## Overview
+
+This document provides a detailed mapping between SOC2 Trust Service Criteria (TSC) and AWS services. The SOC2 framework evaluates an organization's information systems based on five trust service categories:
+
+1. **Security** - The system is protected against unauthorized access (both physical and logical)
+2. **Availability** - The system is available for operation and use as committed or agreed
+3. **Processing Integrity** - System processing is complete, valid, accurate, timely, and authorized
+4. **Confidentiality** - Information designated as confidential is protected as committed or agreed
+5. **Privacy** - Personal information is collected, used, retained, disclosed, and disposed of in conformity with commitments
+
+## How to Use This Framework
+
+To use the SOC2 framework with Service Screener:
+
+```bash
+screener --regions YOUR_REGION --beta 1 --frameworks SOC2
+```
+
+For example, to run in the us-east-1 region:
+
+```bash
+screener --regions us-east-1 --beta 1 --frameworks SOC2
+```
+
+## SOC2 Trust Service Criteria to AWS Service Mapping
+
+### Common Criteria (CC)
+
+#### CC1.0 - Control Environment
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC1.5 - Enforces accountability | IAM | iam.passwordPolicy, iam.rootMfaActive |
+
+#### CC2.0 - Communication and Information
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC2.1 - Information to support internal control | CloudTrail | cloudtrail.multiRegionTrailEnabled, cloudtrail.logFileValidationEnabled |
+| CC2.3 - Communication with external parties | IAM | iam.hasAlternateContact |
+
+#### CC3.0 - Risk Assessment
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC3.2 - Identifies and analyzes risk | GuardDuty, Security Hub | guardduty.isEnabled, securityhub.isEnabled |
+| CC3.3 - Considers potential for fraud | CloudTrail | cloudtrail.cloudwatchLogsEnabled |
+| CC3.4 - Identifies and assesses significant change | Config | config.isEnabled |
+
+#### CC4.0 - Monitoring Activities
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC4.1 - Evaluates and communicates deficiencies | CloudWatch | cloudwatch.hasAlarms |
+| CC4.2 - Evaluates and communicates deficiencies | CloudTrail | cloudtrail.cloudwatchLogsEnabled |
+
+#### CC5.0 - Control Activities
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC5.1 - Selects and develops control activities | IAM | iam.hasOrganization |
+| CC5.2 - Selects and develops general controls over technology | IAM | iam.accessKeysRotated, iam.mfaEnabledForConsoleUsers |
+| CC5.3 - Deploys through policies and procedures | IAM | iam.noRootUserAccessKey |
+
+#### CC6.0 - Logical and Physical Access Controls
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC6.1 - Restricts logical access to authorized users | IAM | iam.usersMfaEnabled, iam.noInlinePolicy, iam.noUserPolicies |
+| CC6.2 - Manages identification and authentication | IAM | iam.passwordPolicy |
+| CC6.3 - Manages logical access | IAM | iam.supportRoleExists, iam.noFullAdminPolicies |
+| CC6.6 - Restricts logical access to information assets | S3 | s3.bucketEncryption, s3.bucketPublicAccessBlock, s3.bucketVersioning |
+| CC6.7 - Restricts the transmission, movement, and removal of information | S3 | s3.bucketLoggingEnabled, s3.bucketPublicAccessBlock |
+| CC6.8 - Manages endpoints | EC2 | ec2.securityGroupsHasDescription, ec2.securityGroupsRestrictedSSH, ec2.securityGroupsRestrictedRDP |
+
+#### CC7.0 - System Operations
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC7.1 - Manages infrastructure, software, and data | EC2 | ec2.instanceDetailedMonitoringEnabled, ec2.ebsOptimizedEnabled |
+| CC7.2 - Manages security incidents | GuardDuty, Security Hub | guardduty.isEnabled, securityhub.isEnabled |
+| CC7.3 - Manages business continuity | AWS Backup, RDS | backup.resourcesProtectedByBackupPlan, rds.instanceBackupEnabled |
+| CC7.4 - Recovers from incidents | RDS, EC2 | rds.instanceMultiAZ, ec2.instanceEbsBackupEnabled |
+
+#### CC8.0 - Change Management
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC8.1 - Manages changes to infrastructure, software, and data | CloudTrail | cloudtrail.multiRegionTrailEnabled |
+
+#### CC9.0 - Risk Mitigation
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| CC9.1 - Identifies, selects, and develops risk mitigation activities | KMS | kms.cmkBackingKeyRotationEnabled, kms.keyRotationEnabled |
+
+### Additional Criteria
+
+#### A1.0 - Availability
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| A1.1 - Maintains, monitors, and evaluates current processing capacity | CloudWatch, EC2 | cloudwatch.hasAlarms, ec2.instanceDetailedMonitoringEnabled |
+| A1.2 - Maintains redundancy, data backup, and disaster recovery | RDS, EC2, AWS Backup | rds.instanceMultiAZ, ec2.instanceEbsBackupEnabled, backup.resourcesProtectedByBackupPlan |
+| A1.3 - Maintains recovery plan | AWS Backup | backup.resourcesProtectedByBackupPlan |
+
+#### C1.0 - Confidentiality
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| C1.1 - Identifies confidential information | S3 | s3.bucketTaggingEnabled |
+| C1.2 - Protects confidential information | S3, RDS, KMS | s3.bucketEncryption, rds.instanceEncryptionEnabled, kms.cmkBackingKeyRotationEnabled |
+
+#### P4.0 - Use, Retention, and Disposal (Privacy)
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| P4.1 - Limits use of personal information | S3 | s3.bucketLifecycleEnabled |
+| P4.2 - Retains personal information consistent with objectives | S3 | s3.bucketLifecycleEnabled |
+| P4.3 - Disposes of personal information | S3 | s3.bucketLifecycleEnabled |
+
+#### P8.0 - Monitoring and Enforcement (Privacy)
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| P8.1 - Monitors compliance with privacy policies | CloudTrail | cloudtrail.multiRegionTrailEnabled, cloudtrail.cloudwatchLogsEnabled |
+
+#### PI1.0 - Processing Integrity
+
+| SOC2 Criteria | AWS Services | Service Screener Checks |
+|---------------|-------------|-------------------------|
+| PI1.1 - Processes inputs accurately, completely, and timely | CloudWatch | cloudwatch.hasAlarms |
+| PI1.2 - Maintains integrity during processing | CloudTrail | cloudtrail.logFileValidationEnabled |
+| PI1.3 - Processes outputs accurately and completely | CloudWatch | cloudwatch.hasAlarms |
+| PI1.4 - Maintains integrity during storage | S3, RDS | s3.bucketVersioning, s3.bucketEncryption, rds.instanceEncryptionEnabled |
+| PI1.5 - Maintains integrity during transmission | CloudFront, API Gateway | cloudfront.viewerPolicyHttps, apigateway.endpointTypesPrivate |
+
+## Extending the Framework
+
+To extend this framework:
+
+1. Add new mappings to the `map.json` file
+2. Create custom checks in the appropriate service directories
+3. Update this documentation to reflect new mappings
+
+## SOC2 Compliance Recommendations
+
+1. **Documentation**: Maintain comprehensive documentation of AWS configurations and controls
+2. **Regular Assessment**: Run Service Screener regularly to identify compliance gaps
+3. **Remediation**: Address identified issues promptly
+4. **Evidence Collection**: Use Service Screener reports as evidence for SOC2 audits
+5. **Continuous Monitoring**: Implement continuous monitoring using CloudWatch and other AWS services

--- a/frameworks/SOC2/SOC2_Implementation_Guide.md
+++ b/frameworks/SOC2/SOC2_Implementation_Guide.md
@@ -1,0 +1,99 @@
+# SOC2 Framework Implementation Guide
+
+## Introduction
+
+This guide provides step-by-step instructions for implementing the SOC2 framework with Service Screener to assess your AWS environment against SOC2 Trust Service Criteria (TSC).
+
+## Prerequisites
+
+1. AWS account with appropriate permissions
+2. Service Screener installed (follow the main README.md instructions)
+3. Basic understanding of SOC2 requirements
+
+## Implementation Steps
+
+### Step 1: Run the SOC2 Framework Assessment
+
+```bash
+screener --regions YOUR_REGION --beta 1 --frameworks SOC2
+```
+
+For multiple regions:
+
+```bash
+screener --regions us-east-1,us-west-2 --beta 1 --frameworks SOC2
+```
+
+### Step 2: Review the Assessment Results
+
+1. Download the output.zip file from CloudShell
+2. Extract the file and open index.html in your browser
+3. Navigate to the SOC2 framework section in the report
+4. Review each control category and its compliance status
+
+### Step 3: Address Non-Compliant Controls
+
+For each non-compliant control:
+
+1. Review the recommendations provided in the report
+2. Implement the suggested changes to your AWS environment
+3. Document the changes made for audit purposes
+4. Re-run the assessment to verify compliance
+
+### Step 4: Prepare for SOC2 Audit
+
+1. Compile evidence of compliance from the Service Screener reports
+2. Document your control environment based on the assessment results
+3. Create a mapping document between SOC2 TSC and your implemented AWS controls
+4. Prepare additional documentation required for SOC2 audit
+
+## Implementation Roadmap
+
+### Phase 1: Initial Assessment (Week 1)
+- Run Service Screener with SOC2 framework
+- Identify compliance gaps
+- Prioritize remediation efforts
+
+### Phase 2: Remediation (Weeks 2-4)
+- Address high-priority compliance gaps
+- Implement missing controls
+- Document changes and justifications
+
+### Phase 3: Verification (Week 5)
+- Re-run Service Screener assessment
+- Verify remediation effectiveness
+- Address any remaining issues
+
+### Phase 4: Documentation (Weeks 6-8)
+- Compile comprehensive documentation
+- Map controls to SOC2 requirements
+- Prepare for external audit
+
+## Common Implementation Challenges
+
+### Challenge 1: Multi-Region Compliance
+**Solution**: Run Service Screener across all regions where you have workloads and consolidate findings.
+
+### Challenge 2: Custom Controls
+**Solution**: For controls not covered by Service Screener, document manual processes and controls separately.
+
+### Challenge 3: Legacy Systems
+**Solution**: Implement compensating controls where direct compliance isn't possible and document exceptions.
+
+## Best Practices
+
+1. **Regular Assessment**: Run the SOC2 framework assessment monthly
+2. **Change Management**: Re-run assessment after significant infrastructure changes
+3. **Documentation**: Maintain up-to-date documentation of all controls
+4. **Automation**: Automate remediation where possible using AWS Config Rules or CloudFormation
+5. **Training**: Ensure team members understand SOC2 requirements and their responsibilities
+
+## Additional Resources
+
+1. AICPA Trust Services Criteria: [https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html](https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html)
+2. AWS Compliance Resources: [https://aws.amazon.com/compliance/resources/](https://aws.amazon.com/compliance/resources/)
+3. AWS Security Best Practices: [https://aws.amazon.com/architecture/security-identity-compliance/](https://aws.amazon.com/architecture/security-identity-compliance/)
+
+## Conclusion
+
+Implementing the SOC2 framework with Service Screener provides a structured approach to achieving and maintaining SOC2 compliance in your AWS environment. By following this guide, you can systematically assess, remediate, and document your compliance posture to prepare for SOC2 audits.

--- a/frameworks/SOC2/SOC2_Implementation_Guide.md
+++ b/frameworks/SOC2/SOC2_Implementation_Guide.md
@@ -4,11 +4,15 @@
 
 This guide provides step-by-step instructions for implementing the SOC2 framework with Service Screener to assess your AWS environment against SOC2 Trust Service Criteria (TSC).
 
+> **Important Note**: Implementing SOC2 controls may have cost and operational impacts on your AWS environment. This guide includes notes about potential cost implications and downtime considerations to help you plan your implementation strategy.
+
 ## Prerequisites
 
 1. AWS account with appropriate permissions
 2. Service Screener installed (follow the main README.md instructions)
 3. Basic understanding of SOC2 requirements
+4. Budget planning for potential cost increases
+5. Change management process for handling service modifications
 
 ## Implementation Steps
 
@@ -36,9 +40,14 @@ screener --regions us-east-1,us-west-2 --beta 1 --frameworks SOC2
 For each non-compliant control:
 
 1. Review the recommendations provided in the report
-2. Implement the suggested changes to your AWS environment
-3. Document the changes made for audit purposes
-4. Re-run the assessment to verify compliance
+2. Assess the cost and operational impact of implementing the control
+3. Implement the suggested changes to your AWS environment
+4. Document the changes made for audit purposes
+5. Re-run the assessment to verify compliance
+
+> **Cost Impact Consideration**: Many SOC2 controls require enabling additional AWS services or features that incur costs. For example, enabling CloudTrail across all regions, implementing Multi-AZ RDS deployments, or activating GuardDuty and Security Hub.
+
+> **Downtime Consideration**: Some remediation actions may require service modifications that could cause temporary downtime. Plan these changes during maintenance windows when possible.
 
 ### Step 4: Prepare for SOC2 Audit
 
@@ -49,36 +58,53 @@ For each non-compliant control:
 
 ## Implementation Roadmap
 
-### Phase 1: Initial Assessment (Week 1)
+### Phase 1: Initial Assessment and Planning (Week 1)
 - Run Service Screener with SOC2 framework
 - Identify compliance gaps
 - Prioritize remediation efforts
+- **Cost Planning**: Estimate budget impact of required changes
+- **Change Management**: Schedule potential service-impacting changes
 
 ### Phase 2: Remediation (Weeks 2-4)
 - Address high-priority compliance gaps
 - Implement missing controls
 - Document changes and justifications
+- **Cost Monitoring**: Track actual costs of implemented changes
+- **Downtime Management**: Implement changes requiring restarts during maintenance windows
 
 ### Phase 3: Verification (Week 5)
 - Re-run Service Screener assessment
 - Verify remediation effectiveness
 - Address any remaining issues
+- **Performance Testing**: Ensure changes haven't negatively impacted performance
 
-### Phase 4: Documentation (Weeks 6-8)
+### Phase 4: Documentation and Preparation (Weeks 6-8)
 - Compile comprehensive documentation
 - Map controls to SOC2 requirements
 - Prepare for external audit
+- **Cost Optimization**: Review implemented controls for cost optimization opportunities
 
 ## Common Implementation Challenges
 
 ### Challenge 1: Multi-Region Compliance
 **Solution**: Run Service Screener across all regions where you have workloads and consolidate findings.
+**Cost Impact**: High - Implementing controls across multiple regions multiplies costs.
 
 ### Challenge 2: Custom Controls
 **Solution**: For controls not covered by Service Screener, document manual processes and controls separately.
+**Cost Impact**: Medium - May require custom development or third-party solutions.
 
 ### Challenge 3: Legacy Systems
 **Solution**: Implement compensating controls where direct compliance isn't possible and document exceptions.
+**Cost Impact**: Varies - Compensating controls may be more or less expensive than direct remediation.
+
+### Challenge 4: Cost Management
+**Solution**: Implement controls incrementally, starting with critical systems, and leverage AWS cost optimization tools.
+**Cost Impact**: Reduces initial implementation costs but extends timeline.
+
+### Challenge 5: Service Disruptions
+**Solution**: Create detailed implementation plans with rollback procedures for service-impacting changes.
+**Downtime Impact**: Proper planning can minimize or eliminate downtime.
 
 ## Best Practices
 
@@ -87,13 +113,34 @@ For each non-compliant control:
 3. **Documentation**: Maintain up-to-date documentation of all controls
 4. **Automation**: Automate remediation where possible using AWS Config Rules or CloudFormation
 5. **Training**: Ensure team members understand SOC2 requirements and their responsibilities
+6. **Cost Monitoring**: Set up AWS Cost Explorer and budgets to track compliance-related costs
+7. **Reserved Instances/Savings Plans**: For long-term compliance requirements, consider purchasing Reserved Instances or Savings Plans
+8. **Resource Tagging**: Implement comprehensive tagging to track compliance-related resources
+9. **Maintenance Windows**: Schedule service-impacting changes during defined maintenance periods
+10. **Testing**: Test changes in non-production environments before applying to production
 
 ## Additional Resources
 
 1. AICPA Trust Services Criteria: [https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html](https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html)
 2. AWS Compliance Resources: [https://aws.amazon.com/compliance/resources/](https://aws.amazon.com/compliance/resources/)
 3. AWS Security Best Practices: [https://aws.amazon.com/architecture/security-identity-compliance/](https://aws.amazon.com/architecture/security-identity-compliance/)
+4. AWS Pricing Calculator: [https://calculator.aws/](https://calculator.aws/)
+5. AWS Well-Architected Framework: [https://aws.amazon.com/architecture/well-architected/](https://aws.amazon.com/architecture/well-architected/)
+
+## Cost Impact by Control Category
+
+| Control Category | Typical Cost Impact | Key Cost Drivers |
+|------------------|---------------------|------------------|
+| IAM Controls | Low | Minimal direct costs |
+| CloudTrail | Medium | Event logging, storage costs |
+| GuardDuty | Medium-High | Data analysis volume |
+| Security Hub | Medium | Base cost plus per-check costs |
+| AWS Config | Medium-High | Configuration items, rules |
+| RDS Multi-AZ | High | Doubles instance costs |
+| S3 Encryption | Low | Slight increase in API costs |
+| CloudWatch | Medium | Metrics, alarms, dashboards |
+| KMS | Low-Medium | Key management, API calls |
 
 ## Conclusion
 
-Implementing the SOC2 framework with Service Screener provides a structured approach to achieving and maintaining SOC2 compliance in your AWS environment. By following this guide, you can systematically assess, remediate, and document your compliance posture to prepare for SOC2 audits.
+Implementing the SOC2 framework with Service Screener provides a structured approach to achieving and maintaining SOC2 compliance in your AWS environment. By following this guide and carefully considering cost and operational impacts, you can systematically assess, remediate, and document your compliance posture to prepare for SOC2 audits while managing your AWS spending effectively.

--- a/frameworks/SOC2/SOC2_Remediation_Guide.md
+++ b/frameworks/SOC2/SOC2_Remediation_Guide.md
@@ -1,0 +1,307 @@
+# SOC2 Remediation Guide
+
+This guide provides remediation steps for common findings identified by the SOC2 framework in Service Screener.
+
+## Security Controls
+
+### IAM Controls
+
+#### Finding: Root account MFA not enabled (iam.rootMfaActive)
+
+**Remediation:**
+```bash
+# Enable MFA for root account through AWS Console
+# 1. Sign in to the AWS Management Console as the root user
+# 2. Choose your account name in the navigation bar, and then choose Security credentials
+# 3. In the Multi-factor authentication (MFA) section, choose Activate MFA
+# 4. Follow the wizard to set up your MFA device
+```
+
+#### Finding: Weak password policy (iam.passwordPolicy)
+
+**Remediation:**
+```bash
+# Set a strong password policy
+aws iam update-account-password-policy \
+    --minimum-password-length 14 \
+    --require-symbols \
+    --require-numbers \
+    --require-uppercase-characters \
+    --require-lowercase-characters \
+    --max-password-age 90 \
+    --password-reuse-prevention 24
+```
+
+#### Finding: MFA not enabled for console users (iam.mfaEnabledForConsoleUsers)
+
+**Remediation:**
+```bash
+# List users without MFA
+aws iam list-users --query 'Users[?UserName!=`null`].[UserName]' --output text | while read user; do
+  if ! aws iam list-mfa-devices --user-name "$user" --query 'MFADevices[*]' --output text | grep -q .; then
+    echo "User without MFA: $user"
+  fi
+done
+
+# Enable MFA for each user through AWS Console
+# 1. Sign in to the AWS Management Console
+# 2. Go to IAM > Users > [Username] > Security credentials
+# 3. In the Multi-factor authentication (MFA) section, choose Assign MFA device
+# 4. Follow the wizard to set up the MFA device
+```
+
+### CloudTrail Controls
+
+#### Finding: Multi-region trail not enabled (cloudtrail.multiRegionTrailEnabled)
+
+**Remediation:**
+```bash
+# Create a multi-region CloudTrail
+aws cloudtrail create-trail \
+    --name soc2-compliance-trail \
+    --s3-bucket-name your-cloudtrail-bucket \
+    --is-multi-region-trail \
+    --enable-log-file-validation
+
+# Start logging
+aws cloudtrail start-logging --name soc2-compliance-trail
+```
+
+#### Finding: Log file validation not enabled (cloudtrail.logFileValidationEnabled)
+
+**Remediation:**
+```bash
+# Update existing trail to enable log file validation
+aws cloudtrail update-trail \
+    --name your-trail-name \
+    --enable-log-file-validation
+```
+
+#### Finding: CloudWatch Logs integration not enabled (cloudtrail.cloudwatchLogsEnabled)
+
+**Remediation:**
+```bash
+# Create CloudWatch Logs group
+aws logs create-log-group --log-group-name CloudTrail/Logs
+
+# Create IAM role for CloudTrail to CloudWatch Logs
+# (Follow AWS documentation for creating the role with appropriate permissions)
+
+# Update trail to use CloudWatch Logs
+aws cloudtrail update-trail \
+    --name your-trail-name \
+    --cloud-watch-logs-log-group-arn arn:aws:logs:region:account-id:log-group:CloudTrail/Logs:* \
+    --cloud-watch-logs-role-arn arn:aws:iam::account-id:role/CloudTrail_CloudWatchLogs_Role
+```
+
+## Availability Controls
+
+### RDS Controls
+
+#### Finding: RDS instances not configured for Multi-AZ (rds.instanceMultiAZ)
+
+**Remediation:**
+```bash
+# Modify RDS instance to enable Multi-AZ
+aws rds modify-db-instance \
+    --db-instance-identifier your-db-instance \
+    --multi-az \
+    --apply-immediately
+```
+
+#### Finding: RDS backups not enabled (rds.instanceBackupEnabled)
+
+**Remediation:**
+```bash
+# Enable automated backups for RDS instance
+aws rds modify-db-instance \
+    --db-instance-identifier your-db-instance \
+    --backup-retention-period 7 \
+    --preferred-backup-window "03:00-05:00" \
+    --apply-immediately
+```
+
+### EC2 Controls
+
+#### Finding: EC2 detailed monitoring not enabled (ec2.instanceDetailedMonitoringEnabled)
+
+**Remediation:**
+```bash
+# Enable detailed monitoring for EC2 instance
+aws ec2 monitor-instances --instance-ids i-1234567890abcdef0
+```
+
+#### Finding: EBS optimization not enabled (ec2.ebsOptimizedEnabled)
+
+**Remediation:**
+```bash
+# Enable EBS optimization (if instance type supports it)
+aws ec2 modify-instance-attribute \
+    --instance-id i-1234567890abcdef0 \
+    --ebs-optimized
+```
+
+## Confidentiality Controls
+
+### S3 Controls
+
+#### Finding: S3 bucket encryption not enabled (s3.bucketEncryption)
+
+**Remediation:**
+```bash
+# Enable default encryption for S3 bucket
+aws s3api put-bucket-encryption \
+    --bucket your-bucket-name \
+    --server-side-encryption-configuration '{
+        "Rules": [
+            {
+                "ApplyServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "AES256"
+                },
+                "BucketKeyEnabled": true
+            }
+        ]
+    }'
+```
+
+#### Finding: S3 bucket public access not blocked (s3.bucketPublicAccessBlock)
+
+**Remediation:**
+```bash
+# Block public access for S3 bucket
+aws s3api put-public-access-block \
+    --bucket your-bucket-name \
+    --public-access-block-configuration '{
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true,
+        "BlockPublicPolicy": true,
+        "RestrictPublicBuckets": true
+    }'
+```
+
+#### Finding: S3 bucket versioning not enabled (s3.bucketVersioning)
+
+**Remediation:**
+```bash
+# Enable versioning for S3 bucket
+aws s3api put-bucket-versioning \
+    --bucket your-bucket-name \
+    --versioning-configuration Status=Enabled
+```
+
+### KMS Controls
+
+#### Finding: KMS key rotation not enabled (kms.keyRotationEnabled)
+
+**Remediation:**
+```bash
+# Enable automatic key rotation for customer managed KMS key
+aws kms enable-key-rotation --key-id 1234abcd-12ab-34cd-56ef-1234567890ab
+```
+
+## Processing Integrity Controls
+
+### CloudWatch Controls
+
+#### Finding: CloudWatch alarms not configured (cloudwatch.hasAlarms)
+
+**Remediation:**
+```bash
+# Create CloudWatch alarm for high CPU utilization
+aws cloudwatch put-metric-alarm \
+    --alarm-name high-cpu-utilization \
+    --comparison-operator GreaterThanThreshold \
+    --evaluation-periods 2 \
+    --metric-name CPUUtilization \
+    --namespace AWS/EC2 \
+    --period 300 \
+    --statistic Average \
+    --threshold 80 \
+    --alarm-description "Alarm when CPU exceeds 80%" \
+    --dimensions "Name=InstanceId,Value=i-1234567890abcdef0" \
+    --alarm-actions arn:aws:sns:region:account-id:topic-name
+```
+
+### CloudFront Controls
+
+#### Finding: CloudFront not using HTTPS (cloudfront.viewerPolicyHttps)
+
+**Remediation:**
+```bash
+# Update CloudFront distribution to enforce HTTPS
+aws cloudfront get-distribution-config --id DISTRIBUTION_ID > dist-config.json
+# Edit dist-config.json to set ViewerProtocolPolicy to "redirect-to-https" or "https-only"
+# Then update the distribution with the modified config
+```
+
+## Privacy Controls
+
+### S3 Controls
+
+#### Finding: S3 bucket lifecycle policies not configured (s3.bucketLifecycleEnabled)
+
+**Remediation:**
+```bash
+# Configure lifecycle policy for S3 bucket
+aws s3api put-bucket-lifecycle-configuration \
+    --bucket your-bucket-name \
+    --lifecycle-configuration '{
+        "Rules": [
+            {
+                "ID": "Delete old data",
+                "Status": "Enabled",
+                "Prefix": "",
+                "Expiration": {
+                    "Days": 365
+                }
+            }
+        ]
+    }'
+```
+
+## Monitoring Controls
+
+### GuardDuty Controls
+
+#### Finding: GuardDuty not enabled (guardduty.isEnabled)
+
+**Remediation:**
+```bash
+# Enable GuardDuty
+aws guardduty create-detector \
+    --enable \
+    --finding-publishing-frequency FIFTEEN_MINUTES
+```
+
+### Security Hub Controls
+
+#### Finding: Security Hub not enabled (securityhub.isEnabled)
+
+**Remediation:**
+```bash
+# Enable Security Hub
+aws securityhub enable-security-hub
+```
+
+### AWS Config Controls
+
+#### Finding: AWS Config not enabled (config.isEnabled)
+
+**Remediation:**
+```bash
+# Enable AWS Config
+aws configservice put-configuration-recorder \
+    --configuration-recorder name=default,roleARN=arn:aws:iam::account-id:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig \
+    --recording-group allSupported=true,includeGlobalResources=true
+
+aws configservice put-delivery-channel \
+    --delivery-channel name=default,s3BucketName=your-config-bucket,configSnapshotDeliveryProperties="{\"deliveryFrequency\":\"Six_Hours\"}"
+
+aws configservice start-configuration-recorder --configuration-recorder-name default
+```
+
+## Conclusion
+
+This remediation guide provides steps to address common SOC2 compliance findings identified by Service Screener. After implementing these remediation steps, re-run the SOC2 framework assessment to verify that the issues have been resolved.
+
+Remember to document all changes made for audit purposes and maintain ongoing compliance through regular assessments.

--- a/frameworks/SOC2/SOC2_Remediation_Guide.md
+++ b/frameworks/SOC2/SOC2_Remediation_Guide.md
@@ -2,9 +2,14 @@
 
 This guide provides remediation steps for common findings identified by the SOC2 framework in Service Screener.
 
+> **Important Note**: Some remediation actions described in this guide may have cost implications or require downtime. Each section includes notes about potential impacts to help you plan your remediation strategy appropriately.
+
 ## Security Controls
 
 ### IAM Controls
+
+> **Cost Impact**: Low - No direct AWS costs associated with these changes.  
+> **Downtime Impact**: None - These changes don't cause service disruptions.
 
 #### Finding: Root account MFA not enabled (iam.rootMfaActive)
 
@@ -52,6 +57,9 @@ done
 
 ### CloudTrail Controls
 
+> **Cost Impact**: Medium - CloudTrail incurs costs based on the number of events recorded and storage in S3. Multi-region trails increase these costs.  
+> **Downtime Impact**: None - Enabling or modifying CloudTrail doesn't cause service disruptions.
+
 #### Finding: Multi-region trail not enabled (cloudtrail.multiRegionTrailEnabled)
 
 **Remediation:**
@@ -98,6 +106,9 @@ aws cloudtrail update-trail \
 
 ### RDS Controls
 
+> **Cost Impact**: High - Multi-AZ deployments approximately double the cost of RDS instances.  
+> **Downtime Impact**: Medium - Enabling Multi-AZ on existing instances may cause brief downtime during the modification.
+
 #### Finding: RDS instances not configured for Multi-AZ (rds.instanceMultiAZ)
 
 **Remediation:**
@@ -123,6 +134,9 @@ aws rds modify-db-instance \
 
 ### EC2 Controls
 
+> **Cost Impact**: Medium - Detailed monitoring incurs additional CloudWatch costs. EBS optimization may increase instance costs depending on the instance type.  
+> **Downtime Impact**: Low to Medium - EBS optimization changes may require instance restart.
+
 #### Finding: EC2 detailed monitoring not enabled (ec2.instanceDetailedMonitoringEnabled)
 
 **Remediation:**
@@ -144,6 +158,9 @@ aws ec2 modify-instance-attribute \
 ## Confidentiality Controls
 
 ### S3 Controls
+
+> **Cost Impact**: Low to Medium - Encryption and versioning may slightly increase costs due to additional API requests and storage for versions.  
+> **Downtime Impact**: None - These changes don't affect availability of S3 buckets.
 
 #### Finding: S3 bucket encryption not enabled (s3.bucketEncryption)
 
@@ -191,6 +208,9 @@ aws s3api put-bucket-versioning \
 
 ### KMS Controls
 
+> **Cost Impact**: Low - KMS key rotation has minimal cost impact beyond the base KMS key costs.  
+> **Downtime Impact**: None - Key rotation doesn't cause service disruptions.
+
 #### Finding: KMS key rotation not enabled (kms.keyRotationEnabled)
 
 **Remediation:**
@@ -202,6 +222,9 @@ aws kms enable-key-rotation --key-id 1234abcd-12ab-34cd-56ef-1234567890ab
 ## Processing Integrity Controls
 
 ### CloudWatch Controls
+
+> **Cost Impact**: Medium - CloudWatch alarms incur costs based on the number of metrics and alarms configured.  
+> **Downtime Impact**: None - Setting up alarms doesn't affect service availability.
 
 #### Finding: CloudWatch alarms not configured (cloudwatch.hasAlarms)
 
@@ -224,6 +247,9 @@ aws cloudwatch put-metric-alarm \
 
 ### CloudFront Controls
 
+> **Cost Impact**: Low - Changing HTTPS settings doesn't directly increase costs, but may increase compute requirements for SSL/TLS handling.  
+> **Downtime Impact**: Low - Distribution updates may cause brief periods of inconsistent behavior during propagation.
+
 #### Finding: CloudFront not using HTTPS (cloudfront.viewerPolicyHttps)
 
 **Remediation:**
@@ -237,6 +263,9 @@ aws cloudfront get-distribution-config --id DISTRIBUTION_ID > dist-config.json
 ## Privacy Controls
 
 ### S3 Controls
+
+> **Cost Impact**: Low - Lifecycle policies may reduce costs by automatically transitioning or deleting objects.  
+> **Downtime Impact**: None - Lifecycle policies don't affect bucket availability.
 
 #### Finding: S3 bucket lifecycle policies not configured (s3.bucketLifecycleEnabled)
 
@@ -263,6 +292,9 @@ aws s3api put-bucket-lifecycle-configuration \
 
 ### GuardDuty Controls
 
+> **Cost Impact**: Medium to High - GuardDuty pricing is based on the volume of data analyzed and varies by region.  
+> **Downtime Impact**: None - Enabling GuardDuty doesn't affect service availability.
+
 #### Finding: GuardDuty not enabled (guardduty.isEnabled)
 
 **Remediation:**
@@ -275,6 +307,9 @@ aws guardduty create-detector \
 
 ### Security Hub Controls
 
+> **Cost Impact**: Medium - Security Hub has a base cost plus per-check costs.  
+> **Downtime Impact**: None - Enabling Security Hub doesn't affect service availability.
+
 #### Finding: Security Hub not enabled (securityhub.isEnabled)
 
 **Remediation:**
@@ -284,6 +319,9 @@ aws securityhub enable-security-hub
 ```
 
 ### AWS Config Controls
+
+> **Cost Impact**: Medium to High - Config costs include configuration items recorded, rules evaluated, and conformance packs.  
+> **Downtime Impact**: None - Enabling Config doesn't affect service availability.
 
 #### Finding: AWS Config not enabled (config.isEnabled)
 
@@ -305,3 +343,23 @@ aws configservice start-configuration-recorder --configuration-recorder-name def
 This remediation guide provides steps to address common SOC2 compliance findings identified by Service Screener. After implementing these remediation steps, re-run the SOC2 framework assessment to verify that the issues have been resolved.
 
 Remember to document all changes made for audit purposes and maintain ongoing compliance through regular assessments.
+
+## Cost and Downtime Planning Considerations
+
+When implementing SOC2 remediation actions, consider the following best practices to manage costs and minimize downtime:
+
+1. **Phased Implementation**: Prioritize critical findings and implement changes gradually to spread out costs.
+
+2. **Maintenance Windows**: Schedule changes that require downtime during designated maintenance windows.
+
+3. **Testing**: Test changes in non-production environments before applying to production.
+
+4. **Cost Monitoring**: Set up AWS Cost Explorer and budgets to monitor the impact of new services.
+
+5. **Reserved Instances/Savings Plans**: For long-term compliance requirements that increase infrastructure needs, consider purchasing Reserved Instances or Savings Plans.
+
+6. **Resource Tagging**: Implement comprehensive tagging to track compliance-related costs separately.
+
+7. **Automation**: Automate remediation where possible to reduce operational overhead.
+
+8. **Consolidated Billing**: Use AWS Organizations and consolidated billing to manage and optimize costs across accounts.

--- a/frameworks/SOC2/map.json
+++ b/frameworks/SOC2/map.json
@@ -1,0 +1,109 @@
+{
+  "metadata": {
+    "originator": "SOC2",
+    "shortname": "SOC2 AWS",
+    "fullname": "SOC2 Trust Services Criteria for AWS",
+    "description": "The SOC2 framework maps AWS service configurations to SOC2 Trust Service Criteria (TSC) requirements. SOC2 is a framework developed by the American Institute of CPAs (AICPA) that specifies how organizations should manage customer data based on five 'trust service criteria': security, availability, processing integrity, confidentiality, and privacy.",
+    "_": "https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html",
+    "emptyCheckDefaultMsg": "<small><i>Please refer to the SOC2 control section for further details. Kindly provide evidence or artifacts demonstrating compliance with the respective SOC2 criteria.</i></small>"
+  },
+  "mapping": {
+    "CC1.0 - Control Environment": {
+      "CC1.1 - Demonstrates commitment to integrity and ethical values": [],
+      "CC1.2 - Board oversight of governance": [],
+      "CC1.3 - Management establishes structure, authority, and responsibility": [],
+      "CC1.4 - Demonstrates commitment to competence": [],
+      "CC1.5 - Enforces accountability": ["iam.passwordPolicy", "iam.rootMfaActive"]
+    },
+    "CC2.0 - Communication and Information": {
+      "CC2.1 - Information to support the functioning of internal control": ["cloudtrail.multiRegionTrailEnabled", "cloudtrail.logFileValidationEnabled"],
+      "CC2.2 - Internal communication of objectives and responsibilities": [],
+      "CC2.3 - Communication with external parties": ["iam.hasAlternateContact"]
+    },
+    "CC3.0 - Risk Assessment": {
+      "CC3.1 - Specifies suitable objectives": [],
+      "CC3.2 - Identifies and analyzes risk": ["guardduty.isEnabled", "securityhub.isEnabled"],
+      "CC3.3 - Considers potential for fraud": ["cloudtrail.cloudwatchLogsEnabled"],
+      "CC3.4 - Identifies and assesses significant change": ["config.isEnabled"]
+    },
+    "CC4.0 - Monitoring Activities": {
+      "CC4.1 - Evaluates and communicates deficiencies": ["cloudwatch.hasAlarms"],
+      "CC4.2 - Evaluates and communicates deficiencies": ["cloudtrail.cloudwatchLogsEnabled"]
+    },
+    "CC5.0 - Control Activities": {
+      "CC5.1 - Selects and develops control activities": ["iam.hasOrganization"],
+      "CC5.2 - Selects and develops general controls over technology": ["iam.accessKeysRotated", "iam.mfaEnabledForConsoleUsers"],
+      "CC5.3 - Deploys through policies and procedures": ["iam.noRootUserAccessKey"]
+    },
+    "CC6.0 - Logical and Physical Access Controls": {
+      "CC6.1 - Restricts logical access to authorized users": ["iam.usersMfaEnabled", "iam.noInlinePolicy", "iam.noUserPolicies"],
+      "CC6.2 - Manages identification and authentication": ["iam.passwordPolicy"],
+      "CC6.3 - Manages logical access": ["iam.supportRoleExists", "iam.noFullAdminPolicies"],
+      "CC6.4 - Restricts physical access": [],
+      "CC6.5 - Manages production changes": [],
+      "CC6.6 - Restricts logical access to information assets": ["s3.bucketEncryption", "s3.bucketPublicAccessBlock", "s3.bucketVersioning"],
+      "CC6.7 - Restricts the transmission, movement, and removal of information": ["s3.bucketLoggingEnabled", "s3.bucketPublicAccessBlock"],
+      "CC6.8 - Manages endpoints": ["ec2.securityGroupsHasDescription", "ec2.securityGroupsRestrictedSSH", "ec2.securityGroupsRestrictedRDP"]
+    },
+    "CC7.0 - System Operations": {
+      "CC7.1 - Manages infrastructure, software, and data": ["ec2.instanceDetailedMonitoringEnabled", "ec2.ebsOptimizedEnabled"],
+      "CC7.2 - Manages security incidents": ["guardduty.isEnabled", "securityhub.isEnabled"],
+      "CC7.3 - Manages business continuity": ["backup.resourcesProtectedByBackupPlan", "rds.instanceBackupEnabled"],
+      "CC7.4 - Recovers from incidents": ["rds.instanceMultiAZ", "ec2.instanceEbsBackupEnabled"]
+    },
+    "CC8.0 - Change Management": {
+      "CC8.1 - Manages changes to infrastructure, software, and data": ["cloudtrail.multiRegionTrailEnabled"],
+      "CC8.2 - Designs and develops changes to infrastructure and software": [],
+      "CC8.3 - Deploys changes to infrastructure and software": []
+    },
+    "CC9.0 - Risk Mitigation": {
+      "CC9.1 - Identifies, selects, and develops risk mitigation activities": ["kms.cmkBackingKeyRotationEnabled", "kms.keyRotationEnabled"],
+      "CC9.2 - Assesses and manages risk associated with vendors and business partners": []
+    },
+    "A1.0 - Availability": {
+      "A1.1 - Maintains, monitors, and evaluates current processing capacity": ["cloudwatch.hasAlarms", "ec2.instanceDetailedMonitoringEnabled"],
+      "A1.2 - Maintains redundancy, data backup, and disaster recovery": ["rds.instanceMultiAZ", "ec2.instanceEbsBackupEnabled", "backup.resourcesProtectedByBackupPlan"],
+      "A1.3 - Maintains recovery plan": ["backup.resourcesProtectedByBackupPlan"]
+    },
+    "C1.0 - Confidentiality": {
+      "C1.1 - Identifies confidential information": ["s3.bucketTaggingEnabled"],
+      "C1.2 - Protects confidential information": ["s3.bucketEncryption", "rds.instanceEncryptionEnabled", "kms.cmkBackingKeyRotationEnabled"]
+    },
+    "P1.0 - Privacy": {
+      "P1.1 - Communicates personal information policies": [],
+      "P1.2 - Provides notice to data subjects": []
+    },
+    "P2.0 - Choice and Consent": {
+      "P2.1 - Describes choices available and obtains consent": []
+    },
+    "P3.0 - Collection": {
+      "P3.1 - Collects personal information consistent with objectives": []
+    },
+    "P4.0 - Use, Retention, and Disposal": {
+      "P4.1 - Limits use of personal information": ["s3.bucketLifecycleEnabled"],
+      "P4.2 - Retains personal information consistent with objectives": ["s3.bucketLifecycleEnabled"],
+      "P4.3 - Disposes of personal information": ["s3.bucketLifecycleEnabled"]
+    },
+    "P5.0 - Access": {
+      "P5.1 - Allows data subjects to access personal information": [],
+      "P5.2 - Discloses personal information consistent with objectives": []
+    },
+    "P6.0 - Disclosure to Third Parties": {
+      "P6.1 - Discloses personal information to third parties consistent with objectives": [],
+      "P6.2 - Assesses whether third parties comply with privacy commitments": []
+    },
+    "P7.0 - Quality": {
+      "P7.1 - Maintains accurate and complete personal information": []
+    },
+    "P8.0 - Monitoring and Enforcement": {
+      "P8.1 - Monitors compliance with privacy policies": ["cloudtrail.multiRegionTrailEnabled", "cloudtrail.cloudwatchLogsEnabled"]
+    },
+    "PI1.0 - Processing Integrity": {
+      "PI1.1 - Processes inputs accurately, completely, and timely": ["cloudwatch.hasAlarms"],
+      "PI1.2 - Maintains integrity during processing": ["cloudtrail.logFileValidationEnabled"],
+      "PI1.3 - Processes outputs accurately and completely": ["cloudwatch.hasAlarms"],
+      "PI1.4 - Maintains integrity during storage": ["s3.bucketVersioning", "s3.bucketEncryption", "rds.instanceEncryptionEnabled"],
+      "PI1.5 - Maintains integrity during transmission": ["cloudfront.viewerPolicyHttps", "apigateway.endpointTypesPrivate"]
+    }
+  }
+}

--- a/frameworks/SOC2/map.json
+++ b/frameworks/SOC2/map.json
@@ -3,9 +3,14 @@
     "originator": "SOC2",
     "shortname": "SOC2 AWS",
     "fullname": "SOC2 Trust Services Criteria for AWS",
-    "description": "The SOC2 framework maps AWS service configurations to SOC2 Trust Service Criteria (TSC) requirements. SOC2 is a framework developed by the American Institute of CPAs (AICPA) that specifies how organizations should manage customer data based on five 'trust service criteria': security, availability, processing integrity, confidentiality, and privacy.",
+    "description": "The SOC2 framework maps AWS service configurations to SOC2 Trust Service Criteria (TSC) requirements. SOC2 is a framework developed by the American Institute of CPAs (AICPA) that specifies how organizations should manage customer data based on five 'trust service criteria': security, availability, processing integrity, confidentiality, and privacy. For detailed implementation guidance, refer to the SOC2_Implementation_Guide.md file in the frameworks/SOC2 directory. For remediation steps to address findings, refer to the SOC2_Remediation_Guide.md file.",
     "_": "https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices.html",
-    "emptyCheckDefaultMsg": "<small><i>Please refer to the SOC2 control section for further details. Kindly provide evidence or artifacts demonstrating compliance with the respective SOC2 criteria.</i></small>"
+    "emptyCheckDefaultMsg": "<small><i>Please refer to the SOC2 control section for further details. Kindly provide evidence or artifacts demonstrating compliance with the respective SOC2 criteria.</i></small>",
+    "documentationFiles": {
+      "implementationGuide": "frameworks/SOC2/SOC2_Implementation_Guide.md",
+      "remediationGuide": "frameworks/SOC2/SOC2_Remediation_Guide.md",
+      "mappingGuide": "frameworks/SOC2/SOC2_AWS_Mapping.md"
+    }
   },
   "mapping": {
     "CC1.0 - Control Environment": {

--- a/frameworks/SOC2/readme.md
+++ b/frameworks/SOC2/readme.md
@@ -10,3 +10,13 @@ The framework covers the five trust service categories:
 - Privacy
 
 Use this framework to assess your AWS environment against SOC2 compliance requirements.
+
+## Documentation Resources
+
+This framework includes the following documentation resources:
+
+1. **SOC2_Implementation_Guide.md** - Step-by-step guide for implementing SOC2 compliance in AWS, including cost and downtime considerations.
+
+2. **SOC2_Remediation_Guide.md** - Detailed remediation steps for common findings, with information about cost impacts and potential service disruptions.
+
+3. **SOC2_AWS_Mapping.md** - Comprehensive mapping between SOC2 Trust Service Criteria and AWS services/checks.

--- a/frameworks/SOC2/readme.md
+++ b/frameworks/SOC2/readme.md
@@ -1,0 +1,12 @@
+# SOC2 Framework for Service Screener
+
+This framework maps AWS service configurations to SOC2 Trust Service Criteria (TSC) requirements.
+
+The framework covers the five trust service categories:
+- Security
+- Availability
+- Processing Integrity
+- Confidentiality
+- Privacy
+
+Use this framework to assess your AWS environment against SOC2 compliance requirements.


### PR DESCRIPTION
## Description
This pull request adds a new SOC2 framework to the service-screener-v2 tool. The SOC2 framework maps AWS service configurations to SOC2 Trust Service Criteria (TSC) requirements, enabling users to assess their AWS environment for SOC2 compliance.

## Features Added
- SOC2 framework implementation with mapping to AWS services
- Comprehensive documentation including:
  - AWS service to SOC2 criteria mapping guide
  - Implementation guide for SOC2 compliance
  - Remediation guide for common SOC2 findings
- Support for all five SOC2 trust service categories:
  - Security
  - Availability
  - Processing Integrity
  - Confidentiality
  - Privacy

## How to Use
Run the service-screener with the SOC2 framework:
```bash
screener --regions YOUR_REGION --beta 1 --frameworks SOC2
```

## Testing Done
- Verified framework structure and file integrity
- Confirmed mapping between SOC2 criteria and AWS service checks