### PR TITLE
Fix typo in replace method for account options

### DIFF
--- a/services/PageBuilder.py
+++ b/services/PageBuilder.py
@@ -485,7 +485,7 @@ $(document).ready(function() {
         
         output.append(
             headerPostCSS.replace('{$ADVISOR_TITLE}', Config.ADVISOR['TITLE'])
-                .replace('{$OPTIONS_ACCOUNTS', self.accountListsHTML())
+                .replace('{$OPTIONS_ACCOUNTS}', self.accountListsHTML())
                 .replace('{$SUPPRESSION_INDICATOR}', suppression_indicator)
         )
         


### PR DESCRIPTION
# Description

Option values are created with a extra character at the end.
```html
<option value='010928212696' selected>12345678912</option>}
```

Fixes # (issue)
 
## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [x] Cosmetic bug fix (non-breaking change)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Single Account, Single Service and Single Region
- [ ] Single Account, Single Service and Multiple Regions
- [ ] Single Account, Multiple Services and Single Region
- [ ] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change with all regions and services
- [ ] Any dependent changes have been merged and published in downstream modules
