### PR TITLE
Fix EC2 no tags and new instance family checking error

### DIFF
--- a/services/ec2/drivers/Ec2Instance.py
+++ b/services/ec2/drivers/Ec2Instance.py
@@ -185,12 +185,14 @@ class Ec2Instance(Evaluator):
        
         try:
             results = self.ec2Client.describe_instance_types(
-                InstanceTypes=[newFamily + '.' + size],
-                MaxResults=1
+                InstanceTypes=[newFamily + '.' + size]
             )
         except Exception as e:
-            self.results['EC2NewGen'] = [1, self.ec2InstanceData['InstanceType']]
-            return
+            if type(e).__name__ == 'ClientError' and e.response['Error']['Code'] == 'InvalidInstanceType':
+                self.results['EC2NewGen'] = [1, self.ec2InstanceData['InstanceType']]
+                return
+            else:
+                raise
     
         self.results['EC2NewGen'] = [-1, self.ec2InstanceData['InstanceType']]
         return

--- a/services/ec2/drivers/Ec2Instance.py
+++ b/services/ec2/drivers/Ec2Instance.py
@@ -480,7 +480,11 @@ class Ec2Instance(Evaluator):
         return
     
     
-    def _checkTags(self):
+    def _checkTags(self):    
+        ## Prevent error when 'Tags' not found in the dict
+        if 'Tags' not in self.ec2InstanceData:
+            return
+        
         tags = self.ec2InstanceData['Tags']
         
         keyTags = []


### PR DESCRIPTION
# Description

- When EC2 without tag, it will shows error that "Tags" is not in the dict
- boto3 EC2 describe_instance_types cannot has MaxResults and InstanceTypes parameters at the same time

Fixes # (issue)

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Single Account, Single Service and Single Region
- [ ] Single Account, Single Service and Multiple Regions
- [ ] Single Account, Multiple Services and Single Region
- [ ] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
