### PR TITLE
Added sequential flag for certain MacOS users experiencing freezing when running the script

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ crossAccounts = _cli_options['crossAccounts']
 workerCounts = _cli_options['workerCounts']
 beta = _cli_options['beta']
 suppress_file = _cli_options['suppress_file']
+sequential = _cli_options['sequential']
 
 # print(crossAccounts)
 DEBUG = True if debugFlag in _C.CLI_TRUE_KEYWORD_ARRAY or debugFlag is True else False
@@ -236,9 +237,15 @@ for acctId, cred in rolesCred.items():
 
     input_ranges = list(input_ranges.values())
 
-    pool = Pool(processes=int(workerCounts))
-    pool.starmap(Screener.scanByService, input_ranges)
-    pool.close()
+    if sequential:
+        # Run sequentially to avoid macOS hanging issues
+        for input_range in input_ranges:
+            Screener.scanByService(*input_range)
+    else:
+        # Run in parallel (default behavior)
+        pool = Pool(processes=int(workerCounts))
+        pool.starmap(Screener.scanByService, input_ranges)
+        pool.close()
 
     if testmode == False:
         CfnTrailObj.deleteStack()

--- a/utils/ArguParser.py
+++ b/utils/ArguParser.py
@@ -85,6 +85,11 @@ class ArguParser:
             "required": False,
             "default": None,
             "help": "Path to JSON file containing suppressions"
+        },
+        'sequential': {
+            "required": False,
+            "default": False,
+            "help": "Run checks sequentially instead of parallel (fixes macOS hanging issues)"
         }
     }
 


### PR DESCRIPTION
# Description

Attempt at addressing #194 where the script freezes/hung on a MacOS by introducing a `--sequential` flag to enable/disable multiprocessing. Multiprocessing is enabled by default unless the flag is specified.

## Type of change

Please delete options that are not relevant, and add any that may be relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Single Account, Single Service and Single Region
- [ ] Single Account, Single Service and Multiple Regions
- [ ] Single Account, Multiple Services and Single Region
- [ ] Single Account, Multiple Services and Multiple Regions
- [ ] CrossAccounts, Multiple Services and Multiple Regions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change with all regions and services
- [x] Any dependent changes have been merged and published in downstream modules
