### PR TITLE
Remove q command references from wa-summarizer

### DIFF
--- a/usecases/wa-summarizer/summarizer_scripts/run_ftr_summarizer.sh
+++ b/usecases/wa-summarizer/summarizer_scripts/run_ftr_summarizer.sh
@@ -261,7 +261,7 @@ main() {
     echo ""
 
     # Check for Kiro CLI
-    if ! command -v q &> /dev/null; then
+    if ! command -v kiro-cli --version &> /dev/null; then
         echo -e "${RED}❌ Kiro CLI is not installed.${NC}"
         echo -e "${YELLOW}ℹ️ Please install Kiro CLI before running this tool.${NC}"
         exit 1

--- a/usecases/wa-summarizer/summarizer_scripts/run_wa_summarizer.sh
+++ b/usecases/wa-summarizer/summarizer_scripts/run_wa_summarizer.sh
@@ -157,7 +157,7 @@ main() {
     echo ""
 
     # Check for Kiro CLI
-    if ! command -v q &> /dev/null; then
+    if ! command -v kiro-cli --version &> /dev/null; then
         echo -e "${RED}❌ Kiro CLI is not installed.${NC}"
         echo -e "${YELLOW}ℹ️ Please install Kiro CLI before running this tool.${NC}"
         exit 1

--- a/usecases/wa-summarizer/summarizer_scripts/run_wa_summarizer_mod.sh
+++ b/usecases/wa-summarizer/summarizer_scripts/run_wa_summarizer_mod.sh
@@ -157,7 +157,7 @@ main() {
     echo ""
 
     # Check for Kiro CLI
-    if ! command -v q &> /dev/null; then
+    if ! command -v kiro-cli --version &> /dev/null; then
         echo -e "${RED}❌ Kiro CLI is not installed.${NC}"
         echo -e "${YELLOW}ℹ️ Please install Kiro CLI before running this tool.${NC}"
         exit 1


### PR DESCRIPTION
# Description

Minot change to remove leftover `q` command references from the wa-summarizer use case scripts.
