### PR TITLE
fix(cloudscape-ui): resolve vite 8 peer dep conflict

### DIFF
--- a/cloudscape-ui/package.json
+++ b/cloudscape-ui/package.json
@@ -22,10 +22,10 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@vitejs/plugin-react": "^4.2.0",
+    "@vitejs/plugin-react": "^5.2.0",
     "typescript": "^5.3.0",
     "vite": "^8.0.8",
-    "vite-plugin-singlefile": "^2.0.0",
+    "vite-plugin-singlefile": "^2.3.3",
     "vitest": "^4.1.4",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.0",


### PR DESCRIPTION
## Problem

`npm install` in `cloudscape-ui/` fails with `ERESOLVE` peer dependency conflict:

```
npm error peer vite@"^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" from @vitejs/plugin-react@4.7.0
npm error peer vite@"^5.4.11 || ^6.0.0 || ^7.0.0" from vite-plugin-singlefile@2.3.0
```

## Root Cause

Dependabot bumped `vite` to `^8.0.8` (PR #234, Apr 10 2026) without also bumping the plugins that depend on it. Both `@vitejs/plugin-react@^4.2.0` and `vite-plugin-singlefile@^2.0.0` lack vite 8 in their peer dep ranges.

## Fix

- Bump `@vitejs/plugin-react` from `^4.2.0` to `^5.2.0` (supports vite 4-8)
- Bump `vite-plugin-singlefile` from `^2.0.0` to `^2.3.3` (supports vite 5-8)

## Testing

- `npm install` completes without errors
- No breaking API changes in either plugin at these versions