### PR TITLE
Feat/eks security checks

### DIFF
--- a/services/ec2/Ec2.py
+++ b/services/ec2/Ec2.py
@@ -10,6 +10,7 @@ import json
 import time
 
 from utils.Tools import _pi
+from utils.Tools import _warn
 
 from utils.Config import Config
 from services.Service import Service
@@ -411,21 +412,35 @@ class Ec2(Service):
         return keyNames
 
     def getSSMManagedInstances(self):
-        """Get set of instance IDs managed by SSM"""
+        """Get set of instance IDs managed by SSM.
+
+        Returns a set of managed instance IDs on success, or None if the
+        SSM API call fails (e.g. missing ssm:DescribeInstanceInformation
+        permission, or SSM unavailable in the region). Returning None lets
+        the caller skip the SSM check entirely instead of flagging every
+        instance as unmanaged (false positives).
+        """
         managedSet = set()
         try:
-            results = self.ssmClient.describe_instance_information()
+            # MaxResults=50 is the API maximum — request full pages to
+            # minimize round-trips for large fleets.
+            results = self.ssmClient.describe_instance_information(MaxResults=50)
             for info in results.get('InstanceInformationList', []):
                 managedSet.add(info['InstanceId'])
             
             while results.get('NextToken'):
                 results = self.ssmClient.describe_instance_information(
+                    MaxResults=50,
                     NextToken=results['NextToken']
                 )
                 for info in results.get('InstanceInformationList', []):
                     managedSet.add(info['InstanceId'])
-        except Exception:
-            pass
+        except botocore.exceptions.ClientError as e:
+            _warn("Unable to retrieve SSM managed instances ({}); skipping SSM check to avoid false positives.".format(e.response['Error']['Code']))
+            return None
+        except Exception as e:
+            _warn("Unable to retrieve SSM managed instances ({}); skipping SSM check to avoid false positives.".format(e))
+            return None
         return managedSet
 
     def getChartGenCost(self):
@@ -715,14 +730,17 @@ class Ec2(Service):
         
         # SSM Managed Instance Checks
         ssmManagedSet = self.getSSMManagedInstances()
-        for instanceArr in instances:
-            for instanceData in instanceArr['Instances']:
-                if instanceData['State']['Name'] not in ('running', 'stopped'):
-                    continue
-                _pi('EC2::SSM Check', instanceData['InstanceId'])
-                obj = Ec2SSM(instanceData['InstanceId'], ssmManagedSet)
-                obj.run(self.__class__)
-                objs[f"SSM::{instanceData['InstanceId']}"] = obj.getInfo()
+        # Skip the SSM check entirely if the managed-instance lookup failed
+        # (getSSMManagedInstances returns None) to avoid false positives.
+        if ssmManagedSet is not None:
+            for instanceArr in instances:
+                for instanceData in instanceArr['Instances']:
+                    if instanceData['State']['Name'] not in ('running', 'stopped'):
+                        continue
+                    _pi('EC2::SSM Check', instanceData['InstanceId'])
+                    obj = Ec2SSM(instanceData['InstanceId'], ssmManagedSet)
+                    obj.run(self.__class__)
+                    objs[f"SSM::{instanceData['InstanceId']}"] = obj.getInfo()
         
         if self.getChartGenCost():
             self.setChartData({"EC2 Instance Family Pricing": self.getChartGenCost()})

--- a/services/ec2/Ec2.py
+++ b/services/ec2/Ec2.py
@@ -428,6 +428,7 @@ class Ec2(Service):
             pass
         return managedSet
 
+    def getChartGenCost(self):
         '''
         Generate Chart by EC2 Instance Type & Region
         Provide customer insight on percentage of older generation EC2 Instance Type

--- a/services/ec2/Ec2.py
+++ b/services/ec2/Ec2.py
@@ -26,6 +26,8 @@ from services.ec2.drivers.Ec2EbsSnapshot import Ec2EbsSnapshot
 from services.ec2.drivers.Ec2Vpc import Ec2Vpc
 from services.ec2.drivers.Ec2NACL import Ec2NACL
 from services.ec2.drivers.Ec2Regional import Ec2Regional
+from services.ec2.drivers.Ec2KeyPair import Ec2KeyPair
+from services.ec2.drivers.Ec2SSM import Ec2SSM
 
 class Ec2(Service):
     CHARTSTYPE = {
@@ -385,11 +387,47 @@ class Ec2(Service):
             result = self.ec2Client.describe_network_acls(
                 NextToken = result.get('NextToken')
             )
-            networkACLs = networkACLs + result.get('NetworkAcls')
+        networkACLs = networkACLs + result.get('NetworkAcls')
         return networkACLs
 
+    def getKeyPairs(self):
+        filters = []
+        if self.tags:
+            filters = self.tags
 
-    def getChartGenCost(self):
+        result = self.ec2Client.describe_key_pairs(
+            Filters=filters
+        )
+        return result.get('KeyPairs', [])
+
+    def getInstanceKeyNames(self, instances):
+        """Collect all key names actively used by running/stopped instances"""
+        keyNames = set()
+        for instanceArr in instances:
+            for instanceData in instanceArr['Instances']:
+                keyName = instanceData.get('KeyName')
+                if keyName:
+                    keyNames.add(keyName)
+        return keyNames
+
+    def getSSMManagedInstances(self):
+        """Get set of instance IDs managed by SSM"""
+        managedSet = set()
+        try:
+            results = self.ssmClient.describe_instance_information()
+            for info in results.get('InstanceInformationList', []):
+                managedSet.add(info['InstanceId'])
+            
+            while results.get('NextToken'):
+                results = self.ssmClient.describe_instance_information(
+                    NextToken=results['NextToken']
+                )
+                for info in results.get('InstanceInformationList', []):
+                    managedSet.add(info['InstanceId'])
+        except Exception:
+            pass
+        return managedSet
+
         '''
         Generate Chart by EC2 Instance Type & Region
         Provide customer insight on percentage of older generation EC2 Instance Type
@@ -664,6 +702,26 @@ class Ec2(Service):
             obj.run(self.__class__)
             objs[f"NACL::{nacl['NetworkAclId']}"] = obj.getInfo()
         
+        
+        # Key Pair Checks
+        keyPairs = self.getKeyPairs()
+        instanceKeyNames = self.getInstanceKeyNames(instances)
+        for kp in keyPairs:
+            _pi('EC2::Key Pair', kp['KeyName'])
+            obj = Ec2KeyPair(kp, instanceKeyNames)
+            obj.run(self.__class__)
+            objs[f"KeyPair::{kp['KeyName']}"] = obj.getInfo()
+        
+        # SSM Managed Instance Checks
+        ssmManagedSet = self.getSSMManagedInstances()
+        for instanceArr in instances:
+            for instanceData in instanceArr['Instances']:
+                if instanceData['State']['Name'] not in ('running', 'stopped'):
+                    continue
+                _pi('EC2::SSM Check', instanceData['InstanceId'])
+                obj = Ec2SSM(instanceData['InstanceId'], ssmManagedSet)
+                obj.run(self.__class__)
+                objs[f"SSM::{instanceData['InstanceId']}"] = obj.getInfo()
         
         if self.getChartGenCost():
             self.setChartData({"EC2 Instance Family Pricing": self.getChartGenCost()})

--- a/services/ec2/drivers/Ec2Instance.py
+++ b/services/ec2/drivers/Ec2Instance.py
@@ -423,7 +423,56 @@ class Ec2Instance(Evaluator):
         if self.ec2InstanceData.get('Tags') is None:
             self.results['EC2HasTag'] = [-1, '']
         return
-    
+
+    def _checkIMDSv2(self):
+        """Check if instance enforces IMDSv2 (HttpTokens = required)"""
+        instance = self.ec2InstanceData
+        metadataOptions = instance.get('MetadataOptions', {})
+        httpTokens = metadataOptions.get('HttpTokens', 'optional')
+        
+        if httpTokens != 'required':
+            self.results['EC2IMDSv2'] = [-1, 'Not enforced']
+        return
+
+    def _checkStoppedTooLong(self):
+        """Flag instances stopped for more than 30 days (still incurring EBS cost)"""
+        instance = self.ec2InstanceData
+        if instance['State']['Name'] != 'stopped':
+            return
+        
+        reason = instance.get('StateTransitionReason', '')
+        # Format: "User initiated (2024-01-15 10:30:00 GMT)"
+        if '(' in reason and ')' in reason:
+            import re
+            match = re.search(r'\((\d{4}-\d{2}-\d{2})', reason)
+            if match:
+                import datetime
+                stopped_date = datetime.datetime.strptime(match.group(1), '%Y-%m-%d').date()
+                days_stopped = (datetime.date.today() - stopped_date).days
+                if days_stopped > 30:
+                    self.results['EC2StoppedTooLong'] = [-1, f'{days_stopped} days']
+        return
+
+    def _checkTerminationProtection(self):
+        """Check if instance has termination protection enabled"""
+        instance = self.ec2InstanceData
+        
+        # Skip terminated/stopped instances
+        if instance['State']['Name'] in ('terminated', 'shutting-down'):
+            return
+        
+        try:
+            resp = self.ec2Client.describe_instance_attribute(
+                InstanceId=instance['InstanceId'],
+                Attribute='disableApiTermination'
+            )
+            protected = resp.get('DisableApiTermination', {}).get('Value', False)
+            if not protected:
+                self.results['EC2NoTerminationProtection'] = [-1, 'Disabled']
+        except Exception:
+            return
+        return
+
     def checkInstanceTypeAvailable(self, instanceType):
         resp = self.ec2Client.describe_instance_type_offerings(
             LocationType='region',

--- a/services/ec2/drivers/Ec2Instance.py
+++ b/services/ec2/drivers/Ec2Instance.py
@@ -1,6 +1,7 @@
 import boto3
 import botocore
 import datetime
+import re
 import time
 from utils.Config import Config
 
@@ -443,10 +444,8 @@ class Ec2Instance(Evaluator):
         reason = instance.get('StateTransitionReason', '')
         # Format: "User initiated (2024-01-15 10:30:00 GMT)"
         if '(' in reason and ')' in reason:
-            import re
             match = re.search(r'\((\d{4}-\d{2}-\d{2})', reason)
             if match:
-                import datetime
                 stopped_date = datetime.datetime.strptime(match.group(1), '%Y-%m-%d').date()
                 days_stopped = (datetime.date.today() - stopped_date).days
                 if days_stopped > 30:
@@ -454,10 +453,22 @@ class Ec2Instance(Evaluator):
         return
 
     def _checkTerminationProtection(self):
-        """Check if instance has termination protection enabled"""
+        """Check if instance has termination protection enabled.
+
+        Stopped instances are intentionally included: they can be critical
+        (e.g. reserved for DR failover) and still benefit from deletion
+        protection. Only terminated/shutting-down instances are skipped.
+
+        This uses describe_instance_attribute, which has no batch form and
+        is therefore called once per instance. The shared boto client is
+        configured with standard retry mode (max_attempts=5), so transient
+        throttling is retried automatically by botocore. If throttling still
+        surfaces after retries, the check is skipped (with a warning) rather
+        than emitting a misleading result.
+        """
         instance = self.ec2InstanceData
         
-        # Skip terminated/stopped instances
+        # Skip terminated/shutting-down instances (nothing left to protect)
         if instance['State']['Name'] in ('terminated', 'shutting-down'):
             return
         
@@ -469,6 +480,13 @@ class Ec2Instance(Evaluator):
             protected = resp.get('DisableApiTermination', {}).get('Value', False)
             if not protected:
                 self.results['EC2NoTerminationProtection'] = [-1, 'Disabled']
+        except botocore.exceptions.ClientError as e:
+            code = e.response['Error']['Code']
+            if code in ('RequestLimitExceeded', 'Throttling', 'ThrottlingException'):
+                _warn("Throttled while checking termination protection for {}; skipping.".format(instance['InstanceId']), forcePrint=False)
+            # Other client errors (e.g. permission) are skipped silently to
+            # avoid emitting a false 'Disabled' result.
+            return
         except Exception:
             return
         return

--- a/services/ec2/drivers/Ec2KeyPair.py
+++ b/services/ec2/drivers/Ec2KeyPair.py
@@ -1,0 +1,22 @@
+import boto3
+import botocore
+
+from services.Evaluator import Evaluator
+
+class Ec2KeyPair(Evaluator):
+    """Check for EC2 key pairs that are not associated with any running instance."""
+    
+    def __init__(self, keyPair, instanceKeyNames):
+        super().__init__()
+        self.keyPair = keyPair
+        self.instanceKeyNames = instanceKeyNames
+
+        self._resourceName = keyPair['KeyName']
+
+        self.init()
+        
+    def _checkKeyPairInUse(self):
+        """Flag key pairs not attached to any running instance"""
+        keyName = self.keyPair['KeyName']
+        if keyName not in self.instanceKeyNames:
+            self.results['EC2KeyPairNotInUse'] = [-1, keyName]

--- a/services/ec2/drivers/Ec2KeyPair.py
+++ b/services/ec2/drivers/Ec2KeyPair.py
@@ -1,4 +1,3 @@
-import boto3
 import botocore
 
 from services.Evaluator import Evaluator

--- a/services/ec2/drivers/Ec2SSM.py
+++ b/services/ec2/drivers/Ec2SSM.py
@@ -1,0 +1,20 @@
+import botocore
+
+from services.Evaluator import Evaluator
+
+class Ec2SSM(Evaluator):
+    """Check if an EC2 instance is managed by AWS Systems Manager."""
+    
+    def __init__(self, instanceId, ssmManagedSet):
+        super().__init__()
+        self.instanceId = instanceId
+        self.ssmManagedSet = ssmManagedSet
+
+        self._resourceName = instanceId
+
+        self.init()
+        
+    def _checkSSMManaged(self):
+        """Flag instances not registered with SSM (no patching/compliance visibility)"""
+        if self.instanceId not in self.ssmManagedSet:
+            self.results['EC2SSMNotManaged'] = [-1, 'Not managed']

--- a/services/ec2/ec2.reporter.json
+++ b/services/ec2/ec2.reporter.json
@@ -51,6 +51,75 @@
             "[Elastic IP Charges]<https://aws.amazon.com/premiumsupport/knowledge-center/elastic-ip-charges/>"       
         ]
     },
+    "EC2KeyPairNotInUse": {
+        "category": "S",
+        "^description": "Unused Key Pairs: {$COUNT} of your EC2 key pairs are not associated with any running instance. Remove unused key pairs to reduce the attack surface and improve security hygiene.",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "criticality": "L",
+        "needFullTest": 0,
+        "shortDesc": "Remove Unused Key Pairs",
+        "ref": [
+            "[Amazon EC2 key pairs]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html>",
+            "[Security best practices]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security.html>"
+        ]
+    },
+    "EC2IMDSv2": {
+        "category": "S",
+        "^description": "IMDSv2 Not Enforced: {$COUNT} of your instances have not enforced IMDSv2 (Instance Metadata Service v2). IMDSv2 adds session-based authentication and mitigates SSRF attacks. Set HttpTokens to 'required' to enforce IMDSv2.",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "criticality": "H",
+        "needFullTest": 1,
+        "shortDesc": "Enforce IMDSv2",
+        "ref": [
+            "[Configure IMDSv2]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>",
+            "[IMDSv2 Best Practices]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html>"
+        ]
+    },
+    "EC2StoppedTooLong": {
+        "category": "C",
+        "^description": "Stopped Instances (>30 days): {$COUNT} of your instances have been in a stopped state for more than 30 days. Stopped instances still incur EBS storage costs. Consider creating an AMI and terminating the instance, or terminate if no longer needed.",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "criticality": "M",
+        "needFullTest": 0,
+        "shortDesc": "Terminate Long-Stopped Instances",
+        "ref": [
+            "[Instance lifecycle]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html>",
+            "[Stop and start instances]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html>"
+        ]
+    },
+    "EC2NoTerminationProtection": {
+        "category": "R",
+        "^description": "No Termination Protection: {$COUNT} of your instances do not have termination protection enabled. Enable termination protection to prevent accidental deletion of critical instances.",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "criticality": "M",
+        "needFullTest": 0,
+        "shortDesc": "Enable Termination Protection",
+        "ref": [
+            "[Enable termination protection]<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_ChangingDisableAPITermination.html>"
+        ]
+    },
+    "EC2SSMNotManaged": {
+        "category": "O",
+        "^description": "SSM Not Managed: {$COUNT} of your instances are not managed by AWS Systems Manager. SSM provides patching, compliance visibility, remote access, and inventory management. Install the SSM agent and attach the required IAM role.",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "criticality": "M",
+        "needFullTest": 0,
+        "shortDesc": "Register with SSM",
+        "ref": [
+            "[Setting up Systems Manager]<https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up.html>",
+            "[SSM Agent]<https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html>"
+        ]
+    },
     "EC2MemoryMonitor": {
         "category": "P",
         "^description": "EC2 Memory Monitoring: Memory monitoring has not been enabled for {$COUNT} of your instances. Install CloudWatch agent and enable the monitoring",

--- a/services/eks/drivers/EksCommon.py
+++ b/services/eks/drivers/EksCommon.py
@@ -156,6 +156,41 @@ class EksCommon(Evaluator):
         
         return
     
+    def _checkPublicEndpointNoCidrRestriction(self):
+        # If the public endpoint is enabled, it should be restricted to
+        # specific CIDRs rather than open to the entire internet (0.0.0.0/0).
+        vpcConfig = self.clusterInfo.get('resourcesVpcConfig', {})
+        if not vpcConfig.get('endpointPublicAccess'):
+            return
+
+        publicAccessCidrs = vpcConfig.get('publicAccessCidrs', [])
+        if not publicAccessCidrs or '0.0.0.0/0' in publicAccessCidrs:
+            self.results['eksPublicEndpointNoCidrRestriction'] = [-1, 'Unrestricted (0.0.0.0/0)']
+
+        return
+
+    def _checkAuthenticationMode(self):
+        # Clusters should use the EKS access entries API for authentication
+        # (API or API_AND_CONFIG_MAP) rather than the legacy aws-auth
+        # ConfigMap (CONFIG_MAP), which is harder to audit and manage.
+        accessConfig = self.clusterInfo.get('accessConfig') or {}
+        authMode = accessConfig.get('authenticationMode')
+
+        # authMode is None on older API responses / very old clusters; only
+        # flag when we can positively confirm CONFIG_MAP is in use.
+        if authMode == 'CONFIG_MAP':
+            self.results['eksAuthModeConfigMap'] = [-1, 'CONFIG_MAP']
+
+        return
+
+    def _checkClusterTags(self):
+        # Clusters should be tagged for cost allocation and governance.
+        tags = self.clusterInfo.get('tags') or {}
+        if len(tags) == 0:
+            self.results['eksClusterNoTags'] = [-1, 'No tags']
+
+        return
+
     def _checkEnvelopeEncryption(self):
         if self.clusterInfo.get('encryptionConfig') is None:
             self.results['eksSecretsEncryption'] = [-1, 'Disabled']

--- a/services/eks/eks.reporter.json
+++ b/services/eks/eks.reporter.json
@@ -1,228 +1,268 @@
 {
-    "eksClusterVersionEol":{
+    "eksClusterVersionEol": {
         "category": "S",
-		"^description": "EKS version end of life: {$COUNT} of your clusters are close to end of life. Please proceed to upgrade your cluster.",
-		"shortDesc": "EKS cluster version end of life",
-		"criticality": "H",
-		"downtime": 1,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[EKS Kubernetes Release Calendar]<https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar>",
-			"[EKS Version Update]<https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html>"
-		]
+        "^description": "EKS version end of life: {$COUNT} of your clusters are close to end of life. Please proceed to upgrade your cluster.",
+        "shortDesc": "EKS cluster version end of life",
+        "criticality": "H",
+        "downtime": 1,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Kubernetes Release Calendar]<https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar>",
+            "[EKS Version Update]<https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html>"
+        ]
     },
-    "eksClusterVersionUpdate":{
+    "eksClusterVersionUpdate": {
         "category": "S",
-		"^description": "EKS new version: Newer version are available for {$COUNT} of your clusters. Please proceed to upgrade your cluster.",
-		"shortDesc": "EKS new version available",
-		"criticality": "M",
-		"downtime": 1,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[EKS Kubernetes Release Calendar]<https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar>",
-			"[EKS Version Update]<https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html>"
-		]
+        "^description": "EKS new version: Newer version are available for {$COUNT} of your clusters. Please proceed to upgrade your cluster.",
+        "shortDesc": "EKS new version available",
+        "criticality": "M",
+        "downtime": 1,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Kubernetes Release Calendar]<https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar>",
+            "[EKS Version Update]<https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html>"
+        ]
     },
-    "eksEndpointPublicAccess":{
+    "eksEndpointPublicAccess": {
         "category": "S",
-		"^description": "EKS public endpoint: {$COUNT} of your clusters have enabled public access for endpoint. Disable public access to minimize the security risks.",
-		"shortDesc": "EKS public endpoint enabled",
-		"criticality": "H",
-		"downtime": 1,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[EKS Endpoint Access Control]<https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html>"
-		]
+        "^description": "EKS public endpoint: {$COUNT} of your clusters have enabled public access for endpoint. Disable public access to minimize the security risks.",
+        "shortDesc": "EKS public endpoint enabled",
+        "criticality": "H",
+        "downtime": 1,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Endpoint Access Control]<https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html>"
+        ]
     },
-    "eksSecretsEncryption":{
+    "eksSecretsEncryption": {
         "category": "S",
-		"^description": "EKS secrets encryption: {$COUNT} of your clusters have disabled secrets encryption. Enable secrets encryption to protect your secrets in your clusters",
-		"shortDesc": "EKS secrets encryption disabled",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 1,
-		"needFullTest": 1,
-		"ref": [
-			"[EKS Secrets Encryption]<https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html>"
-		]
+        "^description": "EKS secrets encryption: {$COUNT} of your clusters have disabled secrets encryption. Enable secrets encryption to protect your secrets in your clusters",
+        "shortDesc": "EKS secrets encryption disabled",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 1,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Secrets Encryption]<https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html>"
+        ]
     },
-    "eksClusterLogging":{
+    "eksClusterLogging": {
         "category": "OS",
-		"^description": "EKS cluster logging: {$COUNT} of your clusters have disabled control plane logging. Enable control plane logging for better monitoring.",
-		"shortDesc": "EKS cluster logging disabled",
-		"criticality": "L",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 1,
-		"needFullTest": 0,
-		"ref": [
-			"[EKS Control Plane Logging]<https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>"
-		]
+        "^description": "EKS cluster logging: {$COUNT} of your clusters have disabled control plane logging. Enable control plane logging for better monitoring.",
+        "shortDesc": "EKS cluster logging disabled",
+        "criticality": "L",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 1,
+        "needFullTest": 0,
+        "ref": [
+            "[EKS Control Plane Logging]<https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>"
+        ]
     },
-    "eksClusterSGRestriction":{
+    "eksClusterSGRestriction": {
         "category": "S",
-		"^description": "EKS cluster security group: {$COUNT} of clusters' security groups have provided permission beyond minimal rules. Grant minimum rules to reduce security risks.",
-		"shortDesc": "EKS cluster security group minimum rules",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[EKS Security Group Requirements]<https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html>"
-		]
+        "^description": "EKS cluster security group: {$COUNT} of clusters' security groups have provided permission beyond minimal rules. Grant minimum rules to reduce security risks.",
+        "shortDesc": "EKS cluster security group minimum rules",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Security Group Requirements]<https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html>"
+        ]
     },
-    "eksClusterRoleLeastPrivilege":{
+    "eksClusterRoleLeastPrivilege": {
         "category": "S",
-		"^description": "EKS role: {$COUNT} of clusters' roles have full access to one or more services.Grant only required permission to reduce the security risks. ",
-		"shortDesc": "EKS rols full access",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[IAM Grant Least Privilege]<https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege>"
-		]
+        "^description": "EKS role: {$COUNT} of clusters' roles have full access to one or more services.Grant only required permission to reduce the security risks. ",
+        "shortDesc": "EKS rols full access",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[IAM Grant Least Privilege]<https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege>"
+        ]
     },
-    "eksNoManagedNodeGroups":{
+    "eksNoManagedNodeGroups": {
         "category": "R",
-		"^description": "EKS managed node groups: {$COUNT} of your clusters have no managed node groups. Use managed node groups for automated provisioning and lifecycle management.",
-		"shortDesc": "No managed node groups configured",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[Managed node groups]<https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html>"
-		]
+        "^description": "EKS managed node groups: {$COUNT} of your clusters have no managed node groups. Use managed node groups for automated provisioning and lifecycle management.",
+        "shortDesc": "No managed node groups configured",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[Managed node groups]<https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html>"
+        ]
     },
-    "eksNodeGroupSingleAZ":{
+    "eksNodeGroupSingleAZ": {
         "category": "R",
-		"^description": "EKS node group availability: {$COUNT} of your node groups are deployed in a single availability zone. Deploy node groups across multiple AZs for high availability.",
-		"shortDesc": "Node group in single AZ",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[Node group networking]<https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html>"
-		]
+        "^description": "EKS node group availability: {$COUNT} of your node groups are deployed in a single availability zone. Deploy node groups across multiple AZs for high availability.",
+        "shortDesc": "Node group in single AZ",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[Node group networking]<https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html>"
+        ]
     },
-    "eksClusterLoggingIncomplete":{
+    "eksClusterLoggingIncomplete": {
         "category": "S",
-		"^description": "EKS control plane logging: {$COUNT} of your clusters have incomplete control plane logging. Enable all log types (api, audit, authenticator, controllerManager, scheduler) for comprehensive monitoring.",
-		"shortDesc": "Incomplete control plane logging",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 1,
-		"needFullTest": 0,
-		"ref": [
-			"[Control plane logging]<https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>"
-		]
+        "^description": "EKS control plane logging: {$COUNT} of your clusters have incomplete control plane logging. Enable all log types (api, audit, authenticator, controllerManager, scheduler) for comprehensive monitoring.",
+        "shortDesc": "Incomplete control plane logging",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 1,
+        "needFullTest": 0,
+        "ref": [
+            "[Control plane logging]<https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>"
+        ]
     },
-    "eksSecretsEncryptionNoKMS":{
+    "eksSecretsEncryptionNoKMS": {
         "category": "S",
-		"^description": "EKS secrets encryption: {$COUNT} of your clusters do not use customer-managed KMS keys for secrets encryption. Use customer-managed KMS keys for better control and compliance.",
-		"shortDesc": "No customer-managed KMS key for secrets",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 1,
-		"needFullTest": 1,
-		"ref": [
-			"[Encrypting secrets]<https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html>"
-		]
+        "^description": "EKS secrets encryption: {$COUNT} of your clusters do not use customer-managed KMS keys for secrets encryption. Use customer-managed KMS keys for better control and compliance.",
+        "shortDesc": "No customer-managed KMS key for secrets",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 1,
+        "needFullTest": 1,
+        "ref": [
+            "[Encrypting secrets]<https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html>"
+        ]
     },
-    "eksNoSpotInstances":{
+    "eksNoSpotInstances": {
         "category": "C",
-		"^description": "EKS Spot instances: {$COUNT} of your clusters have no node groups using Spot instances. Use Spot instances for fault-tolerant workloads to achieve significant cost savings.",
-		"shortDesc": "No Spot instances configured",
-		"criticality": "M",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": -1,
-		"needFullTest": 0,
-		"ref": [
-			"[Managed node groups with Spot]<https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types>"
-		]
+        "^description": "EKS Spot instances: {$COUNT} of your clusters have no node groups using Spot instances. Use Spot instances for fault-tolerant workloads to achieve significant cost savings.",
+        "shortDesc": "No Spot instances configured",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": -1,
+        "needFullTest": 0,
+        "ref": [
+            "[Managed node groups with Spot]<https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types>"
+        ]
     },
-    "eksNoKarpenter":{
+    "eksNoKarpenter": {
         "category": "C",
-		"^description": "EKS Karpenter: {$COUNT} of your clusters do not have Karpenter add-on installed. Use Karpenter for efficient node provisioning and significant cost optimization.",
-		"shortDesc": "Karpenter add-on not installed",
-		"criticality": "M",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": -1,
-		"needFullTest": 0,
-		"ref": [
-			"[Karpenter]<https://karpenter.sh/>",
-			"[EKS Add-ons]<https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html>"
-		]
+        "^description": "EKS Karpenter: {$COUNT} of your clusters do not have Karpenter add-on installed. Use Karpenter for efficient node provisioning and significant cost optimization.",
+        "shortDesc": "Karpenter add-on not installed",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": -1,
+        "needFullTest": 0,
+        "ref": [
+            "[Karpenter]<https://karpenter.sh/>",
+            "[EKS Add-ons]<https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html>"
+        ]
     },
-    "eksAutoModeNotEnabled":{
+    "eksAutoModeNotEnabled": {
         "category": "R",
-		"^description": "EKS Auto Mode: {$COUNT} of your clusters do not have Auto Mode enabled. Use Auto Mode for fully managed compute, networking, and storage to reduce operational overhead.",
-		"shortDesc": "Auto Mode not enabled",
-		"criticality": "M",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 0,
-		"ref": [
-			"[EKS Auto Mode]<https://docs.aws.amazon.com/eks/latest/userguide/automode.html>"
-		]
+        "^description": "EKS Auto Mode: {$COUNT} of your clusters do not have Auto Mode enabled. Use Auto Mode for fully managed compute, networking, and storage to reduce operational overhead.",
+        "shortDesc": "Auto Mode not enabled",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 0,
+        "ref": [
+            "[EKS Auto Mode]<https://docs.aws.amazon.com/eks/latest/userguide/automode.html>"
+        ]
     },
-    "eksNoIRSAConfigured":{
+    "eksNoIRSAConfigured": {
         "category": "S",
-		"^description": "EKS IRSA: {$COUNT} of your clusters do not have OIDC provider configured for IAM Roles for Service Accounts. Use IRSA for pod-level IAM permissions instead of node-level roles.",
-		"shortDesc": "IRSA not configured",
-		"criticality": "H",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 1,
-		"ref": [
-			"[IAM roles for service accounts]<https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html>"
-		]
+        "^description": "EKS IRSA: {$COUNT} of your clusters do not have OIDC provider configured for IAM Roles for Service Accounts. Use IRSA for pod-level IAM permissions instead of node-level roles.",
+        "shortDesc": "IRSA not configured",
+        "criticality": "H",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[IAM roles for service accounts]<https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html>"
+        ]
     },
-    "eksNoAutoscaling":{
+    "eksNoAutoscaling": {
         "category": "C",
-		"^description": "EKS autoscaling: {$COUNT} of your clusters do not have autoscaling configured. Implement cluster autoscaling using Karpenter or node group autoscaling for cost optimization.",
-		"shortDesc": "No autoscaling configured",
-		"criticality": "M",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": -1,
-		"needFullTest": 0,
-		"ref": [
-			"[Autoscaling]<https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html>",
-			"[Karpenter]<https://karpenter.sh/>"
-		]
+        "^description": "EKS autoscaling: {$COUNT} of your clusters do not have autoscaling configured. Implement cluster autoscaling using Karpenter or node group autoscaling for cost optimization.",
+        "shortDesc": "No autoscaling configured",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": -1,
+        "needFullTest": 0,
+        "ref": [
+            "[Autoscaling]<https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html>",
+            "[Karpenter]<https://karpenter.sh/>"
+        ]
     },
-    "eksNoManagedStorageDrivers":{
+    "eksNoManagedStorageDrivers": {
         "category": "R",
-		"^description": "EKS storage drivers: {$COUNT} of your clusters do not have EBS or EFS CSI driver add-ons installed. Use managed storage drivers for persistent storage and data durability.",
-		"shortDesc": "No managed storage drivers",
-		"criticality": "M",
-		"downtime": 0,
-		"slowness": 0,
-		"additionalCost": 0,
-		"needFullTest": 0,
-		"ref": [
-			"[Amazon EBS CSI driver]<https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html>",
-			"[Amazon EFS CSI driver]<https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html>"
-		]
+        "^description": "EKS storage drivers: {$COUNT} of your clusters do not have EBS or EFS CSI driver add-ons installed. Use managed storage drivers for persistent storage and data durability.",
+        "shortDesc": "No managed storage drivers",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 0,
+        "ref": [
+            "[Amazon EBS CSI driver]<https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html>",
+            "[Amazon EFS CSI driver]<https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html>"
+        ]
+    },
+    "eksPublicEndpointNoCidrRestriction": {
+        "category": "S",
+        "^description": "EKS public endpoint unrestricted: {$COUNT} of your clusters expose the public API server endpoint to all IP addresses (0.0.0.0/0). Restrict public access to specific trusted CIDR ranges.",
+        "shortDesc": "EKS public endpoint not restricted to CIDRs",
+        "criticality": "H",
+        "downtime": 1,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Endpoint Access Control]<https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html>"
+        ]
+    },
+    "eksAuthModeConfigMap": {
+        "category": "S",
+        "^description": "EKS legacy authentication mode: {$COUNT} of your clusters use the legacy aws-auth ConfigMap (CONFIG_MAP) for authentication. Migrate to EKS access entries (API or API_AND_CONFIG_MAP) for more secure and auditable access management.",
+        "shortDesc": "EKS using legacy aws-auth ConfigMap",
+        "criticality": "M",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 1,
+        "ref": [
+            "[EKS Access Entries]<https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html>",
+            "[Cluster Authentication]<https://docs.aws.amazon.com/eks/latest/userguide/cluster-auth.html>"
+        ]
+    },
+    "eksClusterNoTags": {
+        "category": "O",
+        "^description": "EKS cluster without tags: {$COUNT} of your clusters have no tags. Tag your EKS clusters for cost allocation and governance.",
+        "shortDesc": "EKS cluster without tagging",
+        "criticality": "L",
+        "downtime": 0,
+        "slowness": 0,
+        "additionalCost": 0,
+        "needFullTest": 0,
+        "ref": [
+            "[Tagging your Amazon EKS resources]<https://docs.aws.amazon.com/eks/latest/userguide/eks-using-tags.html>"
+        ]
     }
 }


### PR DESCRIPTION
## Description

Adds 3 new EKS checks covering Security and Operational Excellence pillars. All three read from the existing `describe_cluster` response (`self.clusterInfo`) — no additional API calls are introduced.

## New Checks

| Check | Result Key | Category | Criticality |
|-------|-----------|----------|-------------|
| Legacy authentication mode | `eksAuthModeConfigMap` | Security | Medium |
| Unrestricted public endpoint | `eksPublicEndpointNoCidrRestriction` | Security | High |
| Missing cluster tags | `eksClusterNoTags` | Operational Excellence | Low |

## Details

1. **`eksAuthModeConfigMap`** — Flags clusters still using the legacy `aws-auth` ConfigMap (`accessConfig.authenticationMode == CONFIG_MAP`). AWS now recommends EKS access entries (`API` / `API_AND_CONFIG_MAP`) for more secure, auditable, IAM-native access management. Only flags when `CONFIG_MAP` is positively confirmed, so older API responses without the field aren't false-flagged.

2. **`eksPublicEndpointNoCidrRestriction`** — The existing `eksEndpointPublicAccess` check flags whether the public endpoint is enabled, but not whether it's restricted. This check flags clusters whose public API server endpoint is open to all IPs (`0.0.0.0/0` in `publicAccessCidrs`, or no CIDR restriction set).

3. **`eksClusterNoTags`** — Flags clusters with no tags, for cost allocation and governance.

## Motivation and Context

These are common EKS hardening gaps not previously covered:
- Access-entry migration is a current AWS security best practice (IAM roles over ConfigMap).
- A public endpoint enabled *and* unrestricted is a materially higher risk than public-but-CIDR-restricted, which the existing check couldn't distinguish.
- Tagging governance aligns with the existing tagging checks in other services (EC2, RDS).

## Breaking Changes

None. Additive checks only. No new API calls (reuses `describe_cluster` data already fetched).

## How Has This Been Tested?

- [x] Python syntax validated
- [x] Reporter keys ↔ driver result keys cross-checked (no orphans)
- [x] New methods auto-discovered by the `Evaluator` (`_check*` convention)
- [x] Defensive `.get()` access with `None`-safe fallbacks